### PR TITLE
Using scotty with settings

### DIFF
--- a/Web/Scotty.hs
+++ b/Web/Scotty.hs
@@ -3,7 +3,7 @@
 -- OverloadedStrings language pragma.
 module Web.Scotty
     ( -- * scotty-to-WAI
-      scotty, scottyApp
+      scotty, scottySettings, scottyApp
       -- * Defining Middleware and Routes
       --
       -- | 'Middleware' and routes are run in the order in which they
@@ -47,7 +47,7 @@ import Data.Text.Lazy.Encoding (encodeUtf8)
 
 import Network.HTTP.Types
 import Network.Wai
-import Network.Wai.Handler.Warp (Port, run)
+import Network.Wai.Handler.Warp (Port, Settings, run, runSettings)
 
 import Web.Scotty.Util
 
@@ -64,6 +64,10 @@ newtype ScottyM a = S { runS :: MS.StateT ScottyState IO a }
 -- | Run a scotty application using the warp server.
 scotty :: Port -> ScottyM () -> IO ()
 scotty p s = putStrLn "Setting phasers to stun... (ctrl-c to quit)" >> (run p =<< scottyApp s)
+
+-- | Run a scotty application using different WAI settings.
+scottySettings :: Settings -> ScottyM() -> IO ()
+scottySettings settings s = putStrLn "Setting phasers to kill... (ctrl-c to quit)" >> (runSettings settings =<< scottyApp s)
 
 -- | Turn a scotty application into a WAI 'Application', which can be
 -- run with any WAI handler.


### PR DESCRIPTION
I added an option to start scotty with different WAI settings.

As it stands currently, you can basically make this function outside of scotty (and I'm currently doing it in a project of mine, where I needed to bind scotty to localhost to put it behind a WebAuth HTTPS proxy), but it's ugly and I think the point of scotty is to keep it so that one can have lovely, concise, kludge-free sinatra-looking code.

Thanks for writing a great, convenient piece of software! :-)
