### PR TITLE
Add "source" function to construct response directly from a Source

### DIFF
--- a/Web/Scotty.hs
+++ b/Web/Scotty.hs
@@ -22,7 +22,7 @@ module Web.Scotty
       --
       -- | Note: only one of these should be present in any given route
       -- definition, as they completely replace the current 'Response' body.
-    , text, html, file, json
+    , text, html, file, json, source
       -- ** Exceptions
     , raise, rescue, next
       -- * Types


### PR DESCRIPTION
Adds a "source" function so that a response can be constructed from a

   Source (ResourceT IO) (Flush Builder)

which is the "native" response source type for WAI.

Use case: Providing streaming data to an HTML5 EventSource in the client application requires a way to generate a streaming reply and Source is the most WAI-esque way of doing that.
