### PR TITLE
added support for file upload

### DIFF
--- a/Web/Scotty/Action.hs
+++ b/Web/Scotty/Action.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Web.Scotty.Action
-    ( request, reqHeader, body, param, params, jsonData
+    ( request, files, reqHeader, body, param, params, jsonData
     , status, header, redirect
     , text, html, file, json, source
     , raise, rescue, next
@@ -26,6 +26,7 @@ import Data.Text.Lazy.Encoding (encodeUtf8)
 
 import Network.HTTP.Types
 import Network.Wai
+import Network.Wai.Parse (File)
 
 import Web.Scotty.Types
 import Web.Scotty.Util
@@ -94,6 +95,9 @@ redirect = throwError . Redirect
 -- | Get the 'Request' object.
 request :: ActionM Request
 request = getReq <$> ask
+
+files :: ActionM [File BL.ByteString]
+files = getFiles <$> ask
 
 -- | Get a request header. Header name is case-insensitive.
 reqHeader :: T.Text -> ActionM T.Text

--- a/Web/Scotty/Types.hs
+++ b/Web/Scotty/Types.hs
@@ -12,6 +12,7 @@ import Data.Text.Lazy (Text, pack)
 
 import Network.Wai
 import Network.Wai.Handler.Warp (Settings, defaultSettings)
+import Network.Wai.Parse(File)
 
 data Options = Options { verbose :: Int -- ^ 0 = silent, 1(def) = startup banner
                        , settings :: Settings -- ^ Warp 'Settings'
@@ -46,7 +47,7 @@ data ActionError = Redirect Text
 instance Error ActionError where
     strMsg = ActionError . pack
 
-data ActionEnv = Env { getReq :: Request, getParams :: [Param], getBody :: ByteString }
+data ActionEnv = Env { getReq :: Request, getParams :: [Param], getBody :: ByteString, getFiles :: [File ByteString] }
 
 newtype ActionM a = AM { runAM :: ErrorT ActionError (ReaderT ActionEnv (StateT Response IO)) a }
     deriving ( Monad, MonadIO, Functor

--- a/scotty.cabal
+++ b/scotty.cabal
@@ -82,7 +82,8 @@ Library
                        text             >= 0.11.1,
                        wai              >= 1.0.0,
                        warp             >= 1.0.0,
-                       regex-compat     >= 0.95.1
+                       regex-compat     >= 0.95.1,
+                       wai-extra        >= 1.2
 
   GHC-options: -Wall -fno-warn-orphans
 


### PR DESCRIPTION
Hi!

I modified mkEnv to get formparams from the function Network.Wai.Parse.parseRequestBody.

I think this reduces code duplication, allows getting form params from a wider array of content types, and adds support for file uploads.
