### PR TITLE
Loosen upper bound of http-types in wai-middleware-static

### DIFF
--- a/wai-middleware-static/wai-middleware-static.cabal
+++ b/wai-middleware-static/wai-middleware-static.cabal
@@ -24,7 +24,7 @@ Library
   Build-depends:       base             >= 4.3.1 && < 5,
                        containers       >= 0.4,
                        directory        >= 1.1,
-                       http-types       >= 0.6.8 && < 0.7,
+                       http-types       >= 0.6.8 && < 0.8,
                        mtl              >= 2.0.1,
                        filepath         >= 1.3.0.0,
                        text             >= 0.11.1,


### PR DESCRIPTION
Thanks for useful app!

Latest scotty can work with http-types 0.7, but wai-middleware-static is not since it has upper bound(< 0.7).
I've built wai-middleware-static w/ http-types 0.7 for my app, and confirmed there' s no problem.
