### PR TITLE
Add function to response by ByteString

### DIFF
--- a/Web/Scotty.hs
+++ b/Web/Scotty.hs
@@ -22,7 +22,7 @@ module Web.Scotty
       --
       -- | Note: only one of these should be present in any given route
       -- definition, as they completely replace the current 'Response' body.
-    , text, html, file, json, source
+    , text, html, file, bytes, json, source
       -- ** Exceptions
     , raise, rescue, next
       -- * Parsing Parameters

--- a/Web/Scotty/Action.hs
+++ b/Web/Scotty/Action.hs
@@ -2,12 +2,12 @@
 module Web.Scotty.Action
     ( request, files, reqHeader, body, param, params, jsonData
     , status, header, redirect
-    , text, html, file, json, source
+    , text, html, file, bytes, json, source
     , raise, rescue, next
     , ActionM, Parsable(..), readEither, Param, runAction
     ) where
 
-import Blaze.ByteString.Builder (Builder, fromLazyByteString)
+import Blaze.ByteString.Builder (Builder, fromLazyByteString, fromByteString)
 
 import Control.Applicative
 import Control.Monad.Error
@@ -204,6 +204,11 @@ html t = do
 -- want to do that on your own with 'header'.
 file :: FilePath -> ActionM ()
 file = MS.modify . setContent . ContentFile
+
+-- | Send bytes as the response. Doesn't set the \"Content-Type\" header, so you probably
+-- want to do that on your own with 'header'.
+bytes :: B.ByteString -> ActionM ()
+bytes = MS.modify . setContent . ContentBuilder . fromByteString
 
 -- | Set the body of the response to the JSON encoding of the given value. Also sets \"Content-Type\"
 -- header to \"application/json\".


### PR DESCRIPTION
There are not enough functions to response by ByteString.
I want to use scotty like this.

``` haskell
main = scotty 3000 do
  gif <- liftIO $ readFile "filepath.gif"
  get "/" $ do
    header "Content-Type" "image/gif"
    bytes gif
```

For example, ByteString for response body is resolved by file, database, STM or else.
