### PR TITLE
This will allow the examples to work out of the box

### DIFF
--- a/examples/clicker.hs
+++ b/examples/clicker.hs
@@ -62,7 +62,7 @@ main = do
             html $ wrapper $ do
                 H.preEscapedLazyText fv
                 H.form ! A.id "login" ! method "post" ! action "/login" $ do
-                    H.text "Enter class key: "
+                    H.h6 "Enter class key: "
                     H.input ! type_ "text" ! name "code"
                     H.br
                     H.input ! type_ "submit"
@@ -85,7 +85,7 @@ main = do
             sId <- maybe (do flash "not logged in!"; redirect "/") return =<< readCookie
             html $ wrapper $ do
                 H.lazyText sId
-                H.a ! href "/logout" $ H.text "Log out"
+                H.a ! href "/logout" $ H.h6 "Log out"
 
         get "/professor" $ do
             text "professor"

--- a/examples/json.hs
+++ b/examples/json.hs
@@ -9,7 +9,7 @@ import Network.Wai.Middleware.Static
 import qualified Text.Blaze.Html5 as H
 import Text.Blaze.Html5 ((!))
 import Text.Blaze.Html5.Attributes as A
-import Text.Blaze.Renderer.Text (renderHtml)
+import Text.Blaze.Html.Renderer.Text (renderHtml)
 
 import Web.Scotty
 
@@ -29,7 +29,7 @@ main = scotty 3000 $ do
     get "/" $ do
         html $ wrapper $ do
             H.form ! A.id "fooform" ! method "post" ! action "#" $ do
-                H.text "Select a constructor: "
+                H.h5 "Select a constructor: "
                 H.input ! type_ "radio" ! A.id "fooquux" ! name "con" ! value "Quux"
                 H.label ! for "fooquux" $ "Quux"
                 H.input ! type_ "radio" ! A.id "foobar" ! name "con" ! value "Bar"
@@ -37,12 +37,12 @@ main = scotty 3000 $ do
                 H.input ! type_ "radio" ! A.id "foobaz" ! name "con" ! value "Baz"
                 H.label ! for "foobaz" $ "Baz"
                 H.br
-                H.text "Enter an int: "
+                H.h5 "Enter an int: "
                 H.input ! type_ "text" ! class_ "barfields" ! name "Barint"
                 H.br
-                H.text "Enter a float: "
+                H.h5 "Enter a float: "
                 H.input ! type_ "text" ! class_ "bazfields" ! name "Bazfloat"
-                H.text "Enter a string: "
+                H.h5 "Enter a string: "
                 H.input ! type_ "text" ! class_ "bazfields" ! name "Bazstring"
                 H.br
                 H.input ! type_ "submit"

--- a/examples/upload.hs
+++ b/examples/upload.hs
@@ -10,7 +10,7 @@ import Network.Wai.Parse
 
 import qualified Text.Blaze.Html5 as H
 import Text.Blaze.Html5.Attributes
-import Text.Blaze.Renderer.Text (renderHtml)
+import Text.Blaze.Html.Renderer.Text (renderHtml)
 
 import qualified Data.ByteString.Lazy as B
 import qualified Data.ByteString.Char8 as BS

--- a/examples/urlshortener.hs
+++ b/examples/urlshortener.hs
@@ -12,7 +12,7 @@ import Network.Wai.Middleware.Static
 
 import qualified Text.Blaze.Html5 as H
 import Text.Blaze.Html5.Attributes
-import Text.Blaze.Renderer.Text (renderHtml)
+import Text.Blaze.Html.Renderer.Text (renderHtml)
 
 -- TODO:
 -- Implement some kind of session and/or cookies


### PR DESCRIPTION
Fixed some deprecated references with Blaze.

Also, clicker.hs isn't working because Util.hs is hidden...

so I used ghc-pkg expose scotty-4.5...

Then there were errors about staticRoot not being in scope. I guess it should be just "static." Still working on finding substitutes for "H.preEscapedLazyText" and `H.lazyText'  
