### PR TITLE
Added ssl support for Scotty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 *.o
 *.swp
 cabal-dev/
+.hsenv

--- a/Web/Scotty.hs
+++ b/Web/Scotty.hs
@@ -1,9 +1,10 @@
-{-# LANGUAGE OverloadedStrings, RankNTypes #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes        #-}
 -- | It should be noted that most of the code snippets below depend on the
 -- OverloadedStrings language pragma.
 module Web.Scotty
     ( -- * scotty-to-WAI
-      scotty, scottyApp, scottyOpts, Options(..)
+      scotty, scottyApp, scottyOpts, scottySSL, Options(..)
       -- * Defining Middleware and Routes
       --
       -- | 'Middleware' and routes are run in the order in which they
@@ -30,24 +31,29 @@ module Web.Scotty
     ) where
 
 -- With the exception of this, everything else better just import types.
-import qualified Web.Scotty.Trans as Trans
+import qualified Web.Scotty.Trans           as Trans
 
-import Blaze.ByteString.Builder (Builder)
+import           Blaze.ByteString.Builder   (Builder)
 
-import Data.Aeson (FromJSON, ToJSON)
-import Data.ByteString.Lazy.Char8 (ByteString)
-import Data.Conduit (Flush, ResourceT, Source)
-import Data.Text.Lazy (Text)
+import           Data.Aeson                 (FromJSON, ToJSON)
+import           Data.ByteString.Lazy.Char8 (ByteString)
+import           Data.Conduit               (Flush, ResourceT, Source)
+import           Data.Text.Lazy             (Text)
 
-import Network.HTTP.Types (Status, StdMethod)
-import Network.Wai (Application, Middleware, Request)
-import Network.Wai.Handler.Warp (Port)
+import           Network.HTTP.Types         (Status, StdMethod)
+import           Network.Wai                (Application, Middleware, Request)
+import           Network.Wai.Handler.Warp   (Port)
 
-import Web.Scotty.Types (Param, ActionM, ScottyM, RoutePattern, Options, File)
+import           Web.Scotty.Types           (ActionM, File, Options, Param,
+                                             RoutePattern, ScottyM)
 
 -- | Run a scotty application using the warp server.
 scotty :: Port -> ScottyM () -> IO ()
 scotty p = Trans.scottyT p id id
+
+-- | Run a scotty application using the warp server over ssl.
+scottySSL :: Port -> FilePath -> FilePath -> ScottyM () -> IO ()
+scottySSL p cert key = Trans.scottySslT cert key p id id
 
 -- | Run a scotty application using the warp server, passing extra options.
 scottyOpts :: Options -> ScottyM () -> IO ()

--- a/scotty.cabal
+++ b/scotty.cabal
@@ -79,7 +79,8 @@ Library
                        transformers     >= 0.3.0.0,
                        wai              >= 1.3.0.1,
                        wai-extra        >= 1.3.0.3,
-                       warp             >= 1.3.4.1
+                       warp             >= 1.3.4.1,
+                       warp-tls         >= 1.4.1.4
 
   GHC-options: -Wall -fno-warn-orphans
 


### PR DESCRIPTION
This adds site-wide SSL to Scotty. Integrated Scotty with the warp-tls package. If running Scotty behind nginx this probably won't be necessary, but stand-alone would be...

Generated a self-signed certificate with key for testing via this heroku doc: https://devcenter.heroku.com/articles/ssl-certificate-self

``` haskell
{-# LANGUAGE OverloadedStrings #-}

import           Web.Scotty

main :: IO ()
main = scottySSL 3000 "server.crt" "server.key" $ do
        get "/" $ do
          html "ok"
```
