### PR TITLE
Added warp-tls integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 *.o
 *.swp
 cabal-dev/
+.hsenv

--- a/scotty.cabal
+++ b/scotty.cabal
@@ -79,7 +79,8 @@ Library
                        transformers     >= 0.3.0.0,
                        wai              >= 1.3.0.1,
                        wai-extra        >= 1.3.0.3,
-                       warp             >= 1.3.4.1
+                       warp             >= 1.3.4.1,
+                       warp-tls         >= 1.4.1.4
 
   GHC-options: -Wall -fno-warn-orphans
 


### PR DESCRIPTION
Decided to forego the Web.Scotty.TLS route since importing scottyApp from Web.Scotty would have caused a circular import. Just included scottyTLS in Web.Scotty.

``` haskell
{-# LANGUAGE OverloadedStrings #-}

import           Web.Scotty

main :: IO ()
main = scottyTLS 3000 "server.key" "server.crt" $ get "/" $ html "ok"
```
