### PR TITLE
Time to upgrade (or loosen?) text dependency

### DIFF
--- a/scotty.cabal
+++ b/scotty.cabal
@@ -78,7 +78,7 @@ Library
                        http-types       >= 0.8.2    && < 0.9,
                        mtl              >= 2.1.2    && < 2.2,
                        regex-compat     >= 0.95.1   && < 0.96,
-                       text             >= 0.11.3.1 && < 0.12,
+                       text             >= 1.0      && < 1.1,
                        transformers     >= 0.3.0.0  && < 0.4,
                        wai              >= 2.0.0    && < 2.1,
                        wai-extra        >= 2.0.1    && < 2.1,


### PR DESCRIPTION
Fails to build with current hackage text version, time to create new package version?
