### PR TITLE
bump text dependency to < 1.2 

### DIFF
--- a/wai-middleware-static/wai-middleware-static.cabal
+++ b/wai-middleware-static/wai-middleware-static.cabal
@@ -1,5 +1,5 @@
 Name:                wai-middleware-static
-Version:             0.4.0.2
+Version:             0.4.0.3
 Synopsis:            WAI middleware that intercepts requests to static files.
 Homepage:            https://github.com/scotty-web/scotty
 Bug-reports:         https://github.com/scotty-web/scotty/issues
@@ -28,7 +28,7 @@ Library
                        http-types       >= 0.8.2    && < 0.9,
                        mtl              >= 2.1.2    && < 2.2,
                        filepath         >= 1.3.0.1  && < 1.4,
-                       text             >= 0.11.3.1 && < 1.1,
+                       text             >= 0.11.3.1 && < 1.2,
                        wai              >= 2.0.0    && < 2.1
 
   GHC-options: -Wall -fno-warn-orphans


### PR DESCRIPTION
text-1.1.0.0 would allow us to use aeson-0.7. 
