### PR TITLE
Indent body of 'do' in README example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ import Web.Scotty
 import Data.Monoid (mconcat)
 
 main = scotty 3000 $ do
-get "/:word" $ do
-  beam <- param "word"
-  html $ mconcat ["<h1>Scotty, ", beam, " me up!</h1>"]
+  get "/:word" $ do
+    beam <- param "word"
+    html $ mconcat ["<h1>Scotty, ", beam, " me up!</h1>"]
 ```
 
 Scotty is the cheap and cheerful way to write RESTful, declarative web applications.


### PR DESCRIPTION
or do you prefer 4 spaces?
