### PR TITLE
added default-language under test-suite spec

### DIFF
--- a/scotty.cabal
+++ b/scotty.cabal
@@ -90,6 +90,7 @@ Library
 test-suite spec
   main-is:             Spec.hs
   type:                exitcode-stdio-1.0
+  default-language:    Haskell2010
   hs-source-dirs:      test
   build-depends:       base,
                        bytestring,


### PR DESCRIPTION
added default-language under 'test-suite spec' in 'scotty.cabal' to allow 'cabal configure --enable-tests' to run
