### PR TITLE
Set charset=utf-8 in Content-Type when serving UTF-8 plaintext and HTML

### DIFF
--- a/Web/Scotty/Action.hs
+++ b/Web/Scotty/Action.hs
@@ -238,17 +238,17 @@ setHeader :: (ScottyError e, Monad m) => T.Text -> T.Text -> ActionT e m ()
 setHeader k v = ActionT . MS.modify $ setHeaderWith $ replace (CI.mk $ lazyTextToStrictByteString k) (lazyTextToStrictByteString v)
 
 -- | Set the body of the response to the given 'T.Text' value. Also sets \"Content-Type\"
--- header to \"text/plain\".
+-- header to \"text/plain; charset=utf-8\".
 text :: (ScottyError e, Monad m) => T.Text -> ActionT e m ()
 text t = do
-    setHeader "Content-Type" "text/plain"
+    setHeader "Content-Type" "text/plain; charset=utf-8"
     raw $ encodeUtf8 t
 
 -- | Set the body of the response to the given 'T.Text' value. Also sets \"Content-Type\"
--- header to \"text/html\".
+-- header to \"text/html; charset=utf-8\".
 html :: (ScottyError e, Monad m) => T.Text -> ActionT e m ()
 html t = do
-    setHeader "Content-Type" "text/html"
+    setHeader "Content-Type" "text/html; charset=utf-8"
     raw $ encodeUtf8 t
 
 -- | Send a file as the response. Doesn't set the \"Content-Type\" header, so you probably

--- a/scotty.cabal
+++ b/scotty.cabal
@@ -95,6 +95,7 @@ test-suite spec
   hs-source-dirs:      test
   build-depends:       base,
                        bytestring,
+                       text,
                        http-types,
                        lifted-base,
                        wai,


### PR DESCRIPTION
Fixes #105
