### PR TITLE
Assume HTTP status 500 for `defaultHandler`

### DIFF
--- a/Web/Scotty/Action.hs
+++ b/Web/Scotty/Action.hs
@@ -225,7 +225,7 @@ readEither t = case [ x | (x,"") <- reads (T.unpack t) ] of
                 _   -> Left "readEither: ambiguous parse"
 
 -- | Set the HTTP response status. Default is 200.
-status :: (ScottyError e, Monad m) => Status -> ActionT e m ()
+status :: Monad m => Status -> ActionT e m ()
 status = ActionT . MS.modify . setStatus
 
 -- | Add to the response headers. Header names are case-insensitive.

--- a/Web/Scotty/Trans.hs
+++ b/Web/Scotty/Trans.hs
@@ -48,7 +48,7 @@ import Control.Monad.IO.Class
 import Data.Conduit (Flush, Source)
 import Data.Default (def)
 
-import Network.HTTP.Types (status404)
+import Network.HTTP.Types (status404, status500)
 import Network.Wai
 import Network.Wai.Handler.Warp (Port, runSettings, setPort, getPort)
 
@@ -115,7 +115,7 @@ notFoundApp _ = return $ responseBuilder status404 [("Content-Type","text/html")
 -- own defaultHandler in production which does not send out the error
 -- strings as 500 responses.
 defaultHandler :: Monad m => (e -> ActionT e m ()) -> ScottyT e m ()
-defaultHandler f = ScottyT $ modify $ addHandler $ Just f
+defaultHandler f = ScottyT $ modify $ addHandler $ Just (\e -> status status500 >> f e)
 
 -- | Use given middleware. Middleware is nested such that the first declared
 -- is the outermost middleware (it has first dibs on the request and last action


### PR DESCRIPTION
(the user can still explicitly specify a different status code)
