### PR TITLE
set default json charset to utf-8 to avoid international chars becoming "garbage"

### DIFF
--- a/Web/Scotty/Action.hs
+++ b/Web/Scotty/Action.hs
@@ -260,7 +260,7 @@ file = ActionT . MS.modify . setContent . ContentFile
 -- header to \"application/json\".
 json :: (A.ToJSON a, ScottyError e, Monad m) => a -> ActionT e m ()
 json v = do
-    setHeader "Content-Type" "application/json"
+    setHeader "Content-Type" "application/json; charset=utf-8"
     raw $ A.encode v
 
 -- | Set the body of the response to a Source. Doesn't set the


### PR DESCRIPTION
Found a case where the swedish characters "öäå" where rendered as "Ã¶Ã¤Ã¥" because "html", "text" and "json" functions in Scotty didn't set a sensible default charset on the Content-Type, hence lets clients/browsers are left to assume it (probably to "us-ascii").

This seems to be fixed in git for most content types, but json still seems to have no charset set. This pull requests sets it to the same default (and sensible) utf-8 charset as elsewhere.
