### PR TITLE
Bump text upper version bounds

### DIFF
--- a/scotty.cabal
+++ b/scotty.cabal
@@ -78,7 +78,7 @@ Library
                        mtl              >= 2.1.2    && < 2.3,
                        monad-control    >= 0.3.2.3  && < 0.4,
                        regex-compat     >= 0.95.1   && < 0.96,
-                       text             >= 0.11.3.1 && < 1.2,
+                       text             >= 0.11.3.1 && < 1.3,
                        transformers     >= 0.3.0.0  && < 0.5,
                        transformers-base >= 0.4.1   && < 0.5,
                        wai              >= 3.0.0    && < 3.1,


### PR DESCRIPTION
Allow `scotty` to use `text-1.2.0.0`.
