### PR TITLE
Create an example of using the reader monad

### DIFF
--- a/examples/reader.hs
+++ b/examples/reader.hs
@@ -1,6 +1,10 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 
+{-
+    An example of embedding a custom monad into Scotty's transformer
+    stack, using ReaderT to provide access to a global state.
+-}
 module Main where
 
 import Control.Applicative (Applicative)


### PR DESCRIPTION
I'm new to Haskell and don't yet grok monad transformers. I wanted to add some state to my Scotty application, so I looked for an example of using `scottyT`. The only one I found was [globalstate.hs](https://github.com/scotty-web/scotty/blob/3bd7a09feb906be6d549c3d2f276b40a30eba6af/examples/globalstate.hs), which complicated things by including STM. So I decided to pare that down and create my own example. 
