### PR TITLE
Fix for monad-control-1.0.0.0

### DIFF
--- a/Web/Scotty/Internal/Types.hs
+++ b/Web/Scotty/Internal/Types.hs
@@ -160,21 +160,21 @@ instance (MonadBase b m, ScottyError e) => MonadBase b (ActionT e m) where
 
 instance ScottyError e => MonadTransControl (ActionT e) where
 #if MIN_VERSION_mtl(2,2,1)
-     newtype StT (ActionT e) a = StAction {unStAction :: StT (StateT ScottyResponse) (StT (ReaderT ActionEnv) (StT (ExceptT (ActionError e)) a))}
+     type StT (ActionT e) a = StT (StateT ScottyResponse) (StT (ReaderT ActionEnv) (StT (ExceptT (ActionError e)) a))
 #else
-     newtype StT (ActionT e) a = StAction {unStAction :: StT (StateT ScottyResponse) (StT (ReaderT ActionEnv) (StT (ErrorT (ActionError e)) a))}
+     type StT (ActionT e) a = StT (StateT ScottyResponse) (StT (ReaderT ActionEnv) (StT (ErrorT (ActionError e)) a))
 #endif
      liftWith = \f ->
         ActionT $  liftWith $ \run  ->
                    liftWith $ \run' ->
                    liftWith $ \run'' ->
-                   f $ liftM StAction . run'' . run' . run . runAM
-     restoreT = ActionT . restoreT . restoreT . restoreT . liftM unStAction
+                   f $ run'' . run' . run . runAM
+     restoreT = ActionT . restoreT . restoreT . restoreT
 
 instance (ScottyError e, MonadBaseControl b m) => MonadBaseControl b (ActionT e m) where
-    newtype StM (ActionT e m) a = STMAction {unStMActionT :: ComposeSt (ActionT e) m a}
-    liftBaseWith = defaultLiftBaseWith STMAction
-    restoreM     = defaultRestoreM   unStMActionT
+    type StM (ActionT e m) a = ComposeSt (ActionT e) m a
+    liftBaseWith = defaultLiftBaseWith
+    restoreM     = defaultRestoreM
 
 ------------------ Scotty Routes --------------------
 data RoutePattern = Capture   Text

--- a/scotty.cabal
+++ b/scotty.cabal
@@ -76,7 +76,7 @@ Library
                        data-default     >= 0.5.3    && < 0.6,
                        http-types       >= 0.8.2    && < 0.9,
                        mtl              >= 2.1.2    && < 2.3,
-                       monad-control    >= 0.3.2.3  && < 0.4,
+                       monad-control    >= 1.0.0.0  && < 1.1,
                        regex-compat     >= 0.95.1   && < 0.96,
                        text             >= 0.11.3.1 && < 1.3,
                        transformers     >= 0.3.0.0  && < 0.5,


### PR DESCRIPTION
As of `monad-control-1.0.0.0`, `MonadTransControl` and `MonadBaseControl` now use an associated type instead of associated data.
