### PR TITLE
Fix building (and examples) with base-4.8.0.0

### DIFF
--- a/Web/Scotty/Action.hs
+++ b/Web/Scotty/Action.hs
@@ -46,7 +46,9 @@ import qualified Data.ByteString.Char8      as B
 import qualified Data.ByteString.Lazy.Char8 as BL
 import qualified Data.CaseInsensitive       as CI
 import           Data.Default               (def)
+#if !(MIN_VERSION_base(4,8,0))
 import           Data.Monoid                (mconcat)
+#endif
 import qualified Data.Text                  as ST
 import qualified Data.Text.Lazy             as T
 import           Data.Text.Lazy.Encoding    (encodeUtf8)

--- a/Web/Scotty/Internal/Types.hs
+++ b/Web/Scotty/Internal/Types.hs
@@ -3,7 +3,9 @@ module Web.Scotty.Internal.Types where
 
 import           Blaze.ByteString.Builder (Builder)
 
+#if !(MIN_VERSION_base(4,8,0))
 import           Control.Applicative
+#endif
 import qualified Control.Exception as E
 import           Control.Monad.Base (MonadBase, liftBase, liftBaseDefault)
 #if MIN_VERSION_mtl(2,2,1)
@@ -18,7 +20,9 @@ import           Control.Monad.Trans.Control (MonadBaseControl, StM, liftBaseWit
 import qualified Data.ByteString as BS
 import           Data.ByteString.Lazy.Char8 (ByteString)
 import           Data.Default (Default, def)
+#if !(MIN_VERSION_base(4,8,0))
 import           Data.Monoid (mempty)
+#endif
 import           Data.String (IsString(..))
 import           Data.Text.Lazy (Text, pack)
 import           Data.Typeable (Typeable)

--- a/Web/Scotty/Route.hs
+++ b/Web/Scotty/Route.hs
@@ -18,7 +18,9 @@ import qualified Control.Monad.State as MS
 import qualified Data.ByteString.Char8 as B
 import qualified Data.ByteString.Lazy.Char8 as BL
 import           Data.Maybe (fromMaybe, isJust)
+#if !(MIN_VERSION_base(4,8,0))
 import           Data.Monoid (mconcat)
+#endif
 import           Data.String (fromString)
 import qualified Data.Text.Lazy as T
 import qualified Data.Text as TS

--- a/examples/basic.hs
+++ b/examples/basic.hs
@@ -1,16 +1,18 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP, OverloadedStrings #-}
+module Main (main) where
+
 import Web.Scotty
 
 import Network.Wai.Middleware.RequestLogger -- install wai-extra if you don't have this
 
 import Control.Monad
 import Control.Monad.Trans
+#if !(MIN_VERSION_base(4,8,0))
 import Data.Monoid
+#endif
 import System.Random (newStdGen, randomRs)
 
 import Network.HTTP.Types (status302)
-import Network.Wai
-import qualified Data.Text.Lazy as T
 
 import Data.Text.Lazy.Encoding (decodeUtf8)
 import Data.String (fromString)
@@ -45,12 +47,12 @@ main = scotty 3000 $ do
 
     -- redirects preempt execution
     get "/redirect" $ do
-        redirect "http://www.google.com"
+        void $ redirect "http://www.google.com"
         raise "this error is never reached"
 
     -- Of course you can catch your own errors.
     get "/rescue" $ do
-        (do raise "a rescued error"; redirect "http://www.we-never-go-here.com")
+        (do void $ raise "a rescued error"; redirect "http://www.we-never-go-here.com")
         `rescue` (\m -> text $ "we recovered from " `mappend` m)
 
     -- Parts of the URL that start with a colon match
@@ -65,7 +67,7 @@ main = scotty 3000 $ do
 
     -- You can stop execution of this action and keep pattern matching routes.
     get "/random" $ do
-        next
+        void next
         redirect "http://www.we-never-go-here.com"
 
     -- You can do IO with liftIO, and you can return JSON content.

--- a/examples/bodyecho.hs
+++ b/examples/bodyecho.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-module Main where
+module Main (main) where
 
 import Web.Scotty
 

--- a/examples/cookies.hs
+++ b/examples/cookies.hs
@@ -1,9 +1,10 @@
 {-# LANGUAGE OverloadedStrings #-}
 -- This examples requires you to: cabal install cookie
 -- and: cabal install blaze-html
+module Main (main) where
+
 import Control.Monad (forM_)
 import Data.Text.Lazy (Text)
-import qualified Data.Text.Lazy as T
 import qualified Data.Text.Lazy.Encoding as T
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
@@ -27,7 +28,7 @@ setCookie n v = setHeader "Set-Cookie" (renderSetCookie' (makeCookie n v))
 getCookies :: ActionM (Maybe CookiesText)
 getCookies =
     fmap (fmap (parseCookiesText . lazyToStrict . T.encodeUtf8)) $
-        reqHeader "Cookie"
+        header "Cookie"
     where
         lazyToStrict = BS.concat . BSL.toChunks
 
@@ -37,9 +38,9 @@ renderCookiesTable cs =
         H.tr $ do
             H.th "name"
             H.th "value"
-        forM_ cs $ \(name, val) -> do
+        forM_ cs $ \(name', val) -> do
             H.tr $ do
-                H.td (H.toMarkup name)
+                H.td (H.toMarkup name')
                 H.td (H.toMarkup val)
 
 main :: IO ()
@@ -56,7 +57,7 @@ main = scotty 3000 $ do
                 H.input H.! type_ "submit" H.! value "set a cookie"
 
     post "/set-a-cookie" $ do
-        name <- param "name"
-        value <- param "value"
-        setCookie name value
+        name'  <- param "name"
+        value' <- param "value"
+        setCookie name' value'
         redirect "/"

--- a/examples/exceptions.hs
+++ b/examples/exceptions.hs
@@ -1,9 +1,6 @@
 {-# LANGUAGE CPP, OverloadedStrings, GeneralizedNewtypeDeriving, ScopedTypeVariables #-}
 module Main (main) where
 
-#if !(MIN_VERSION_base(4,8,0))
-import Control.Applicative
-#endif
 import Control.Monad.IO.Class
 
 #if !(MIN_VERSION_base(4,8,0))

--- a/examples/exceptions.hs
+++ b/examples/exceptions.hs
@@ -1,15 +1,18 @@
-{-# LANGUAGE OverloadedStrings, GeneralizedNewtypeDeriving, ScopedTypeVariables #-}
-module Main where
+{-# LANGUAGE CPP, OverloadedStrings, GeneralizedNewtypeDeriving, ScopedTypeVariables #-}
+module Main (main) where
 
+#if !(MIN_VERSION_base(4,8,0))
 import Control.Applicative
-import Control.Monad.Error
+#endif
+import Control.Monad.IO.Class
 
+#if !(MIN_VERSION_base(4,8,0))
 import Data.Monoid
+#endif
 import Data.String (fromString)
 
 import Network.HTTP.Types
 import Network.Wai.Middleware.RequestLogger
-import Network.Wai
 
 import System.Random
 
@@ -51,7 +54,7 @@ main = scottyT 3000 id id $ do -- note, we aren't using any additional transform
 
     get "/switch/:val" $ do
         v <- param "val"
-        if even v then raise Forbidden else raise (NotFound v)
+        _ <- if even v then raise Forbidden else raise (NotFound v)
         text "this will never be reached"
 
     get "/random" $ do

--- a/examples/globalstate.hs
+++ b/examples/globalstate.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE CPP, OverloadedStrings, GeneralizedNewtypeDeriving #-}
 -- An example of embedding a custom monad into
 -- Scotty's transformer stack, using ReaderT to provide access
 -- to a TVar containing global state.
@@ -7,8 +7,11 @@
 -- is IO itself. The types of 'scottyT' and 'scottyAppT' are
 -- general enough to allow a Scotty application to be
 -- embedded into any MonadIO monad.
-module Main where
+module Main (main) where
 
+#if !(MIN_VERSION_base(4,8,0))
+import Control.Applicative
+#endif
 import Control.Concurrent.STM
 import Control.Monad.Reader
 
@@ -36,7 +39,7 @@ instance Default AppState where
 -- Also note: your monad must be an instance of 'MonadIO' for
 -- Scotty to use it.
 newtype WebM a = WebM { runWebM :: ReaderT (TVar AppState) IO a }
-    deriving (Monad, MonadIO, MonadReader (TVar AppState))
+    deriving (Applicative, Functor, Monad, MonadIO, MonadReader (TVar AppState))
 
 -- Scotty's monads are layered on top of our custom monad.
 -- We define this synonym for lift in order to be explicit

--- a/examples/gzip.hs
+++ b/examples/gzip.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
+module Main (main) where
+
 import Network.Wai.Middleware.RequestLogger
 import Network.Wai.Middleware.Gzip
 

--- a/examples/options.hs
+++ b/examples/options.hs
@@ -1,15 +1,17 @@
 {-# LANGUAGE OverloadedStrings #-}
+module Main (main) where
+
 import Web.Scotty
 
 import Network.Wai.Middleware.RequestLogger -- install wai-extra if you don't have this
 
 import Data.Default (def)
-import Network.Wai.Handler.Warp (settingsPort)
+import Network.Wai.Handler.Warp (setPort)
 
 -- Set some Scotty settings
 opts :: Options
 opts = def { verbose = 0
-           , settings = (settings def) { settingsPort = 4000 }
+           , settings = setPort 4000 $ settings def
            }
 
 -- This won't display anything at startup, and will listen on localhost:4000

--- a/examples/reader.hs
+++ b/examples/reader.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -7,7 +8,9 @@
 -}
 module Main where
 
+#if !(MIN_VERSION_base(4,8,0))
 import Control.Applicative (Applicative)
+#endif
 import Control.Monad.Reader (MonadIO, MonadReader, ReaderT, asks, lift, runReaderT)
 import Data.Default (def)
 import Data.Text.Lazy (Text, pack)

--- a/examples/upload.hs
+++ b/examples/upload.hs
@@ -1,8 +1,12 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP, OverloadedStrings #-}
+module Main (main) where
+
 import Web.Scotty
 
 import Control.Monad.IO.Class
+#if !(MIN_VERSION_base(4,8,0))
 import Data.Monoid
+#endif
 
 import Network.Wai.Middleware.RequestLogger
 import Network.Wai.Middleware.Static

--- a/examples/urlshortener.hs
+++ b/examples/urlshortener.hs
@@ -1,10 +1,14 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP, OverloadedStrings #-}
+module Main (main) where
+
 import Web.Scotty
 
 import Control.Concurrent.MVar
 import Control.Monad.IO.Class
 import qualified Data.Map as M
+#if !(MIN_VERSION_base(4,8,0))
 import Data.Monoid (mconcat)
+#endif
 import qualified Data.Text.Lazy as T
 
 import Network.Wai.Middleware.RequestLogger


### PR DESCRIPTION
Much of `Control.Applicative` and `Data.Monoid` are exposed in `Prelude` as of `base-4.8.0.0`, so don't import them if using that version of `base` or later. This also fixes some examples that were broken by the Applicative–Monad Proposal (as well as lots of warnings).