### PR TITLE
Use data-default-class instead of data-default

### DIFF
--- a/Web/Scotty/Action.hs
+++ b/Web/Scotty/Action.hs
@@ -45,7 +45,7 @@ import qualified Data.Aeson                 as A
 import qualified Data.ByteString.Char8      as B
 import qualified Data.ByteString.Lazy.Char8 as BL
 import qualified Data.CaseInsensitive       as CI
-import           Data.Default               (def)
+import           Data.Default.Class         (def)
 import           Data.Monoid                (mconcat)
 import qualified Data.Text                  as ST
 import qualified Data.Text.Lazy             as T

--- a/Web/Scotty/Internal/Types.hs
+++ b/Web/Scotty/Internal/Types.hs
@@ -17,7 +17,7 @@ import           Control.Monad.Trans.Control (MonadBaseControl, StM, liftBaseWit
 
 import qualified Data.ByteString as BS
 import           Data.ByteString.Lazy.Char8 (ByteString)
-import           Data.Default (Default, def)
+import           Data.Default.Class (Default, def)
 import           Data.Monoid (mempty)
 import           Data.String (IsString(..))
 import           Data.Text.Lazy (Text, pack)

--- a/Web/Scotty/Trans.hs
+++ b/Web/Scotty/Trans.hs
@@ -45,7 +45,7 @@ import Control.Monad (when)
 import Control.Monad.State (execStateT, modify)
 import Control.Monad.IO.Class
 
-import Data.Default (def)
+import Data.Default.Class (def)
 
 import Network (Socket)
 import Network.HTTP.Types (status404, status500)

--- a/examples/globalstate.hs
+++ b/examples/globalstate.hs
@@ -12,7 +12,7 @@ module Main where
 import Control.Concurrent.STM
 import Control.Monad.Reader
 
-import Data.Default
+import Data.Default.Class
 import Data.String
 import Data.Text.Lazy (Text)
 

--- a/examples/options.hs
+++ b/examples/options.hs
@@ -3,7 +3,7 @@ import Web.Scotty
 
 import Network.Wai.Middleware.RequestLogger -- install wai-extra if you don't have this
 
-import Data.Default (def)
+import Data.Default.Class (def)
 import Network.Wai.Handler.Warp (settingsPort)
 
 -- Set some Scotty settings

--- a/examples/reader.hs
+++ b/examples/reader.hs
@@ -9,7 +9,7 @@ module Main where
 
 import Control.Applicative (Applicative)
 import Control.Monad.Reader (MonadIO, MonadReader, ReaderT, asks, lift, runReaderT)
-import Data.Default (def)
+import Data.Default.Class (def)
 import Data.Text.Lazy (Text, pack)
 import Web.Scotty.Trans (ScottyT, get, scottyOptsT, text)
 

--- a/scotty.cabal
+++ b/scotty.cabal
@@ -68,23 +68,23 @@ Library
                        Web.Scotty.Route
                        Web.Scotty.Util
   default-language:    Haskell2010
-  build-depends:       aeson            >= 0.6.2.1  && < 0.9,
-                       base             >= 4.3.1    && < 5,
-                       blaze-builder    >= 0.3.3.0  && < 0.4,
-                       bytestring       >= 0.10.0.2 && < 0.11,
-                       case-insensitive >= 1.0.0.1  && < 1.3,
-                       data-default     >= 0.5.3    && < 0.6,
-                       http-types       >= 0.8.2    && < 0.9,
-                       mtl              >= 2.1.2    && < 2.3,
-                       monad-control    >= 1.0.0.0  && < 1.1,
-                       network          >= 2.6.0.2  && < 2.7,
-                       regex-compat     >= 0.95.1   && < 0.96,
-                       text             >= 0.11.3.1 && < 1.3,
-                       transformers     >= 0.3.0.0  && < 0.5,
-                       transformers-base >= 0.4.1   && < 0.5,
-                       wai              >= 3.0.0    && < 3.1,
-                       wai-extra        >= 3.0.0    && < 3.1,
-                       warp             >= 3.0.0    && < 3.1
+  build-depends:       aeson              >= 0.6.2.1  && < 0.9,
+                       base               >= 4.3.1    && < 5,
+                       blaze-builder      >= 0.3.3.0  && < 0.4,
+                       bytestring         >= 0.10.0.2 && < 0.11,
+                       case-insensitive   >= 1.0.0.1  && < 1.3,
+                       data-default-class >= 0.0.1    && < 0.1,
+                       http-types         >= 0.8.2    && < 0.9,
+                       mtl                >= 2.1.2    && < 2.3,
+                       monad-control      >= 1.0.0.0  && < 1.1,
+                       network            >= 2.6.0.2  && < 2.7,
+                       regex-compat       >= 0.95.1   && < 0.96,
+                       text               >= 0.11.3.1 && < 1.3,
+                       transformers       >= 0.3.0.0  && < 0.5,
+                       transformers-base  >= 0.4.1    && < 0.5,
+                       wai                >= 3.0.0    && < 3.1,
+                       wai-extra          >= 3.0.0    && < 3.1,
+                       warp               >= 3.0.0    && < 3.1
 
   GHC-options: -Wall -fno-warn-orphans
 
@@ -95,7 +95,7 @@ test-suite spec
   hs-source-dirs:      test
   build-depends:       async,
                        base,
-                       data-default,
+                       data-default-class,
                        directory,
                        hspec == 2.*,
                        hspec-wai >= 0.6.3,

--- a/test/Web/ScottySpec.hs
+++ b/test/Web/ScottySpec.hs
@@ -17,7 +17,7 @@ import qualified Web.Scotty as Scotty
 
 #ifndef WINDOWS
 import           Control.Concurrent.Async (withAsync)
-import           Data.Default (def)
+import           Data.Default.Class (def)
 import           Network (listenOn, PortID(..))
 import           Network.Socket
 import           System.Directory (removeFile)


### PR DESCRIPTION
The `data-default` package has a large number of `*-instances` dependencies (`data-default-instances-base`, `data-default-instances-containers`, `data-default-instances-dlist`, and `data-default-instances-old-locale`), none of which `scotty` actually uses. This commit replaces it with `data-default-class`, a simpler package that only defines `Default(def)` with no additional dependencies.