### PR TITLE
Bump blaze-builder upper version bounds

### DIFF
--- a/scotty.cabal
+++ b/scotty.cabal
@@ -70,7 +70,7 @@ Library
   default-language:    Haskell2010
   build-depends:       aeson              >= 0.6.2.1  && < 0.9,
                        base               >= 4.3.1    && < 5,
-                       blaze-builder      >= 0.3.3.0  && < 0.4,
+                       blaze-builder      >= 0.3.3.0  && < 0.5,
                        bytestring         >= 0.10.0.2 && < 0.11,
                        case-insensitive   >= 1.0.0.1  && < 1.3,
                        data-default-class >= 0.0.1    && < 0.1,

--- a/scotty.cabal
+++ b/scotty.cabal
@@ -70,6 +70,7 @@ Library
   default-language:    Haskell2010
   build-depends:       aeson              >= 0.6.2.1  && < 0.9,
                        base               >= 4.3.1    && < 5,
+                       -- Someday, this should be replaced with bytestring-builder
                        blaze-builder      >= 0.3.3.0  && < 0.5,
                        bytestring         >= 0.10.0.2 && < 0.11,
                        case-insensitive   >= 1.0.0.1  && < 1.3,


### PR DESCRIPTION
`blaze-builder` recently updated to version 0.4, in which the `Builder` type is now a [`bytestring-builder`](http://hackage.haskell.org/package/bytestring-0.10.4.1/docs/Data-ByteString-Builder.html#t:Builder) internally. Although you could just replace the `blaze-builder` dependency with `bytestring-builder`, since `scotty` exposes the `Builder` type [as part of its API](http://hackage.haskell.org/package/scotty-0.9.1/docs/Web-Scotty-Internal-Types.html#t:Content), it would probably be best to do a simple version bump to avoid breaking any packages that use `ContentBuilder`.