### PR TITLE
Use mingw32_HOST_OS pragma for non-Windows code

### DIFF
--- a/Web/Scotty/Util.hs
+++ b/Web/Scotty/Util.hs
@@ -70,6 +70,6 @@ socketDescription = fmap d . socketPort
     where d p = case p of
                     Service s -> "service " ++ s
                     PortNumber (PortNum n) -> "port " ++ show n
-#ifndef WINDOWS
+#ifndef mingw32_HOST_OS
                     UnixSocket u -> "unix socket " ++ u
 #endif

--- a/test/Web/ScottySpec.hs
+++ b/test/Web/ScottySpec.hs
@@ -15,7 +15,7 @@ import qualified Control.Exception as E
 import           Web.Scotty as Scotty hiding (get, post, put, patch, delete, request, options)
 import qualified Web.Scotty as Scotty
 
-#ifndef WINDOWS
+#ifndef mingw32_HOST_OS
 import           Control.Concurrent.Async (withAsync)
 import           Data.Default.Class (def)
 import           Network (listenOn, PortID(..))
@@ -138,7 +138,7 @@ spec = do
           get "/scotty" `shouldRespondWith` 200 {matchHeaders = ["Content-Type" <:> "text/somethingweird"]}
 
 -- Unix sockets not available on Windows
-#ifndef WINDOWS
+#ifndef mingw32_HOST_OS
   describe "scottySocket" .
     it "works with a unix socket" .
       withServer (Scotty.get "/scotty" $ html "") .


### PR DESCRIPTION
`scotty` doesn't build correctly for me on Windows, and I'm guessing it's because the `WINDOWS` macro isn't actually defined. I replaced it with `mingw32_HOST_OS` to fix the problem.