### PR TITLE
Decouple scottyT monad

### DIFF
--- a/Web/Scotty.hs
+++ b/Web/Scotty.hs
@@ -53,23 +53,23 @@ type ActionM = ActionT Text IO
 
 -- | Run a scotty application using the warp server.
 scotty :: Port -> ScottyM () -> IO ()
-scotty p = Trans.scottyT p id id
+scotty p = Trans.scottyT p id
 
 -- | Run a scotty application using the warp server, passing extra options.
 scottyOpts :: Options -> ScottyM () -> IO ()
-scottyOpts opts = Trans.scottyOptsT opts id id
+scottyOpts opts = Trans.scottyOptsT opts id
 
 -- | Run a scotty application using the warp server, passing extra options,
 -- and listening on the provided socket. This allows the user to provide, for
 -- example, a Unix named socket, which can be used when reverse HTTP proxying
 -- into your application.
 scottySocket :: Options -> Socket -> ScottyM () -> IO ()
-scottySocket opts sock = Trans.scottySocketT opts sock id id
+scottySocket opts sock = Trans.scottySocketT opts sock id
 
 -- | Turn a scotty application into a WAI 'Application', which can be
 -- run with any WAI handler.
 scottyApp :: ScottyM () -> IO Application
-scottyApp = Trans.scottyAppT id id
+scottyApp = Trans.scottyAppT id
 
 -- | Global handler for uncaught exceptions.
 --

--- a/Web/Scotty/Internal/Types.hs
+++ b/Web/Scotty/Internal/Types.hs
@@ -66,11 +66,9 @@ addRoute r s@(ScottyState {routes = rs}) = s { routes = r:rs }
 addHandler :: ErrorHandler e m -> ScottyState e m -> ScottyState e m
 addHandler h s = s { handler = h }
 
-newtype ScottyT e m a = ScottyT { runS :: StateT (ScottyState e m) m a }
-    deriving ( Functor, Applicative, Monad, MonadIO )
+newtype ScottyT e m a = ScottyT { runS :: State (ScottyState e m) a }
+    deriving ( Functor, Applicative, Monad )
 
-instance MonadTrans (ScottyT e) where
-    lift = ScottyT . lift
 
 ------------------ Scotty Errors --------------------
 data ActionError e = Redirect Text

--- a/Web/Scotty/Trans.hs
+++ b/Web/Scotty/Trans.hs
@@ -102,7 +102,7 @@ scottyAppT :: (Monad m, Monad n)
            -> ScottyT e m ()
            -> n Application
 scottyAppT runActionToIO defs = do
-    s <- return $ execState (runS defs) def
+    let s = execState (runS defs) def
     let rapp req callback = runActionToIO (foldl (flip ($)) notFoundApp (routes s) req) >>= callback
     return $ foldl (flip ($)) rapp (middlewares s)
 

--- a/examples/exceptions.hs
+++ b/examples/exceptions.hs
@@ -35,8 +35,8 @@ handleEx (NotFound i) = do
     html $ fromString $ "<h1>Can't find " ++ show i ++ ".</h1>"
 
 main :: IO ()
-main = scottyT 3000 id id $ do -- note, we aren't using any additional transformer layers
-                               -- so we can just use 'id' for the runners.
+main = scottyT 3000 id $ do -- note, we aren't using any additional transformer layers
+                            -- so we can just use 'id' for the runner.
     middleware logStdoutDev
 
     defaultHandler handleEx    -- define what to do with uncaught exceptions

--- a/examples/globalstate.hs
+++ b/examples/globalstate.hs
@@ -57,12 +57,10 @@ modify f = ask >>= liftIO . atomically . flip modifyTVar' f
 main :: IO ()
 main = do
     sync <- newTVarIO def
-        -- Note that 'runM' is only called once, at startup.
-    let runM m = runReaderT (runWebM m) sync
         -- 'runActionToIO' is called once per action.
-        runActionToIO = runM
+    let runActionToIO m = runReaderT (runWebM m) sync
 
-    scottyT 3000 runM runActionToIO app
+    scottyT 3000 runActionToIO app
 
 -- This app doesn't use raise/rescue, so the exception
 -- type is ambiguous. We can fix it by putting a type

--- a/examples/reader.hs
+++ b/examples/reader.hs
@@ -29,12 +29,9 @@ application = do
     text $ pack $ show e
 
 main :: IO ()
-main = scottyOptsT def runM runIO application where
-  runM :: ConfigM a -> IO a
-  runM m = runReaderT (runConfigM m) config
-
+main = scottyOptsT def runIO application where
   runIO :: ConfigM a -> IO a
-  runIO = runM
+  runIO m = runReaderT (runConfigM m) config
 
   config :: Config
   config = Config

--- a/examples/urlshortener.hs
+++ b/examples/urlshortener.hs
@@ -28,7 +28,7 @@ import Text.Blaze.Html.Renderer.Text (renderHtml)
 
 main :: IO ()
 main = do
-  m <- liftIO $ newMVar (0::Int,M.empty :: M.Map Int T.Text)
+  m <- newMVar (0::Int,M.empty :: M.Map Int T.Text)
   scotty 3000 $ do
     middleware logStdoutDev
     middleware static

--- a/examples/urlshortener.hs
+++ b/examples/urlshortener.hs
@@ -27,11 +27,11 @@ import Text.Blaze.Html.Renderer.Text (renderHtml)
 -- Add links
 
 main :: IO ()
-main = scotty 3000 $ do
+main = do
+  m <- liftIO $ newMVar (0::Int,M.empty :: M.Map Int T.Text)
+  scotty 3000 $ do
     middleware logStdoutDev
     middleware static
-
-    m <- liftIO $ newMVar (0::Int,M.empty :: M.Map Int T.Text)
 
     get "/" $ do
         html $ renderHtml


### PR DESCRIPTION
This removes the `runM` parameter to the `scotty*[T]` functions and thus decouples the monad stacks of `ScottyT` and `ActionT` as suggested in issue #74.

All tests still pass and all examples still build (and work).

These changes actually clean up the examples, by not requiring passing the same parameter twice – often “disguised” by aliasing the name (see `examples/globalstate.hs` for an example). The only real change is that you now have to do global initialization before calling `scotty*[T]`. A good example of this is the changes in `examples/urlshortener.hs` where the `MVar` initialization is done before calling `scotty` instead of being part of `scotty`'s `do` block.

(If merged, scotty's versjon also needs to be bumped.)