### PR TITLE
Fix use of deprecated `PortNum` constructor

### DIFF
--- a/Web/Scotty/Util.hs
+++ b/Web/Scotty/Util.hs
@@ -13,7 +13,6 @@ module Web.Scotty.Util
     ) where
 
 import Network (Socket, PortID(..), socketPort)
-import Network.Socket (PortNumber(..))
 import Network.Wai
 
 import Network.HTTP.Types
@@ -69,7 +68,7 @@ socketDescription :: Socket -> IO String
 socketDescription = fmap d . socketPort
     where d p = case p of
                     Service s -> "service " ++ s
-                    PortNumber (PortNum n) -> "port " ++ show n
+                    PortNumber n -> "port " ++ show n
 #if !defined(mingw32_HOST_OS)
                     UnixSocket u -> "unix socket " ++ u
 #endif


### PR DESCRIPTION
This fixes the use of the deprecated `PortNum` constructor that was used for showing the port number for a socket, and uses `PortNumber`'s `Show` instance instead. This instance is in all versions of `network` scotty can use (scotty depends on `>= 2.6.0.2`).