### PR TITLE
Make ScottyT a transformer again

### DIFF
--- a/Web/Scotty.hs
+++ b/Web/Scotty.hs
@@ -48,7 +48,7 @@ import Network.Wai.Handler.Warp (Port)
 
 import Web.Scotty.Internal.Types (ScottyT, ActionT, Param, RoutePattern, Options, File)
 
-type ScottyM = ScottyT Text IO
+type ScottyM = ScottyT Text IO IO
 type ActionM = ActionT Text IO
 
 -- | Run a scotty application using the warp server.

--- a/Web/Scotty/Internal/Types.hs
+++ b/Web/Scotty/Internal/Types.hs
@@ -66,8 +66,8 @@ addRoute r s@(ScottyState {routes = rs}) = s { routes = r:rs }
 addHandler :: ErrorHandler e m -> ScottyState e m -> ScottyState e m
 addHandler h s = s { handler = h }
 
-newtype ScottyT e m a = ScottyT { runS :: State (ScottyState e m) a }
-    deriving ( Functor, Applicative, Monad )
+newtype ScottyT e m n a = ScottyT { runS :: StateT (ScottyState e m) n a }
+    deriving ( Functor, Applicative, Monad, MonadFix, MonadTrans, MonadIO )
 
 
 ------------------ Scotty Errors --------------------

--- a/Web/Scotty/Route.hs
+++ b/Web/Scotty/Route.hs
@@ -32,36 +32,36 @@ import           Web.Scotty.Internal.Types
 import           Web.Scotty.Util
 
 -- | get = 'addroute' 'GET'
-get :: (ScottyError e, MonadIO m) => RoutePattern -> ActionT e m () -> ScottyT e m ()
+get :: (ScottyError e, MonadIO m, Monad n) => RoutePattern -> ActionT e m () -> ScottyT e m n ()
 get = addroute GET
 
 -- | post = 'addroute' 'POST'
-post :: (ScottyError e, MonadIO m) => RoutePattern -> ActionT e m () -> ScottyT e m ()
+post :: (ScottyError e, MonadIO m, Monad n) => RoutePattern -> ActionT e m () -> ScottyT e m n ()
 post = addroute POST
 
 -- | put = 'addroute' 'PUT'
-put :: (ScottyError e, MonadIO m) => RoutePattern -> ActionT e m () -> ScottyT e m ()
+put :: (ScottyError e, MonadIO m, Monad n) => RoutePattern -> ActionT e m () -> ScottyT e m n ()
 put = addroute PUT
 
 -- | delete = 'addroute' 'DELETE'
-delete :: (ScottyError e, MonadIO m) => RoutePattern -> ActionT e m () -> ScottyT e m ()
+delete :: (ScottyError e, MonadIO m, Monad n) => RoutePattern -> ActionT e m () -> ScottyT e m n ()
 delete = addroute DELETE
 
 -- | patch = 'addroute' 'PATCH'
-patch :: (ScottyError e, MonadIO m) => RoutePattern -> ActionT e m () -> ScottyT e m ()
+patch :: (ScottyError e, MonadIO m, Monad n) => RoutePattern -> ActionT e m () -> ScottyT e m n ()
 patch = addroute PATCH
 
 -- | options = 'addroute' 'OPTIONS'
-options :: (ScottyError e, MonadIO m) => RoutePattern -> ActionT e m () -> ScottyT e m ()
+options :: (ScottyError e, MonadIO m, Monad n) => RoutePattern -> ActionT e m () -> ScottyT e m n ()
 options = addroute OPTIONS
 
 -- | Add a route that matches regardless of the HTTP verb.
-matchAny :: (ScottyError e, MonadIO m) => RoutePattern -> ActionT e m () -> ScottyT e m ()
+matchAny :: (ScottyError e, MonadIO m, Monad n) => RoutePattern -> ActionT e m () -> ScottyT e m n ()
 matchAny pattern action = mapM_ (\v -> addroute v pattern action) [minBound..maxBound]
 
 -- | Specify an action to take if nothing else is found. Note: this _always_ matches,
 -- so should generally be the last route specified.
-notFound :: (ScottyError e, MonadIO m) => ActionT e m () -> ScottyT e m ()
+notFound :: (ScottyError e, MonadIO m, Monad n) => ActionT e m () -> ScottyT e m n ()
 notFound action = matchAny (Function (\req -> Just [("path", path req)])) (status status404 >> action)
 
 -- | Define a route with a 'StdMethod', 'T.Text' value representing the path spec,
@@ -78,7 +78,7 @@ notFound action = matchAny (Function (\req -> Just [("path", path req)])) (statu
 --
 -- >>> curl http://localhost:3000/foo/something
 -- something
-addroute :: (ScottyError e, MonadIO m) => StdMethod -> RoutePattern -> ActionT e m () -> ScottyT e m ()
+addroute :: (ScottyError e, MonadIO m, Monad n) => StdMethod -> RoutePattern -> ActionT e m () -> ScottyT e m n ()
 addroute method pat action = ScottyT $ MS.modify $ \s -> addRoute (route (handler s) method pat action) s
 
 route :: (ScottyError e, MonadIO m) => ErrorHandler e m -> StdMethod -> RoutePattern -> ActionT e m () -> Middleware m


### PR DESCRIPTION
We can have decoupled monads for `ScottyT` and `ActionT` if `ScottyT` is parametrised by two monads. This breaks the API a lot because it changes the kind of `ScottyT` but it allows for composable components.
With this change it is possible to write several "components" of type `ScottyT e m n a` and bind them together. By a "component" I mean something that can do its own setup and teardown in some custom monad stack (e.g. open db connection in IO).
This is currently not possible since `ScottyT` is not a true transformer but fixed over `Identity` and thus limited to manipulating the `ScottyState` and not doing any other effects. 
You can still do something like
```haskell
myComponent :: MyMonadStack (ScottyM ())
myComponent = do 
  db <- openDbConnection
  return $ do $ 
    get "/" $ html "hello"
    -- other scotty stuff using db
```
But this is awkward to use (and confusing to newcomers, since `ActionT` *is* a transformer) since you have to bind the components together **and** manually assemble them. Which is just the abstraction that transformers provide.

With this PR you can simplify to
```haskell
myComponent :: ScottyT Text IO MyMonadStack ()
myComponent = do 
  db <- lift openDbConnection
  get "/" $ html "hello"
  -- other scotty stuff using db
```

And use it with just the regular `do` notation.