### PR TITLE
Update http-types range.

### DIFF
--- a/scotty.cabal
+++ b/scotty.cabal
@@ -74,7 +74,7 @@ Library
                        bytestring          >= 0.10.0.2 && < 0.11,
                        case-insensitive    >= 1.0.0.1  && < 1.3,
                        data-default-class  >= 0.0.1    && < 0.1,
-                       http-types          >= 0.8.2    && < 0.9,
+                       http-types          >= 0.8.2    && < 0.10,
                        monad-control       >= 1.0.0.3  && < 1.1,
                        mtl                 >= 2.1.2    && < 2.3,
                        nats                >= 0.1      && < 2,


### PR DESCRIPTION
http-types 0.9 has been released 
http://hackage.haskell.org/package/http-types