### PR TITLE
Finish

### DIFF
--- a/Web/Scotty.hs
+++ b/Web/Scotty.hs
@@ -26,7 +26,7 @@ module Web.Scotty
       -- definition, as they completely replace the current 'Response' body.
     , text, html, file, json, stream, raw
       -- ** Exceptions
-    , raise, rescue, next, defaultHandler, liftAndCatchIO
+    , raise, rescue, next, finish, defaultHandler, liftAndCatchIO
       -- * Parsing Parameters
     , Param, Trans.Parsable(..), Trans.readEither
       -- * Types
@@ -110,6 +110,21 @@ raise = Trans.raise
 -- >   text $ "You made a request to: " <> w
 next :: ActionM a
 next = Trans.next
+
+-- | Abort execution of this action. Like an exception, any code after 'finish'
+-- is not executed.
+--
+-- As an example only requests to /foo/special will include in the response
+-- content the text message.
+--
+-- > get "/foo/:bar" $ do
+-- >   w :: Text <- param "bar"
+-- >   unless (w == "special") finish
+-- >   text "You made a request to /foo/special"
+--
+-- /Since: 0.10.3/
+finish :: ActionM a
+finish = Trans.finish
 
 -- | Catch an exception thrown by 'raise'.
 --

--- a/Web/Scotty/Action.hs
+++ b/Web/Scotty/Action.hs
@@ -7,6 +7,7 @@ module Web.Scotty.Action
     , bodyReader
     , file
     , files
+    , finish
     , header
     , headers
     , html
@@ -83,6 +84,7 @@ defH Nothing    (ActionError e)   = do
     html $ mconcat ["<h1>500 Internal Server Error</h1>", showError e]
 defH h@(Just f) (ActionError e)   = f e `catchError` (defH h) -- so handlers can throw exceptions themselves
 defH _          Next              = next
+defH _          Finish            = return ()
 
 -- | Throw an exception, which can be caught with 'rescue'. Uncaught exceptions
 -- turn into HTTP 500 responses.
@@ -130,6 +132,13 @@ liftAndCatchIO io = ActionT $ do
 -- > redirect "/foo/bar"
 redirect :: (ScottyError e, Monad m) => T.Text -> ActionT e m a
 redirect = throwError . Redirect
+
+-- | Finish the execution of the current action. Like throwing an uncatchable
+-- exception. Any code after the call to finish will not be run.
+--
+-- /Since: 0.10.3/
+finish :: (ScottyError e, Monad m) => ActionT e m a
+finish = throwError Finish
 
 -- | Get the 'Request' object.
 request :: Monad m => ActionT e m Request

--- a/Web/Scotty/Internal/Types.hs
+++ b/Web/Scotty/Internal/Types.hs
@@ -73,6 +73,7 @@ newtype ScottyT e m a = ScottyT { runS :: State (ScottyState e m) a }
 ------------------ Scotty Errors --------------------
 data ActionError e = Redirect Text
                    | Next
+                   | Finish
                    | ActionError e
 
 -- | In order to use a custom exception type (aside from 'Text'), you must
@@ -89,6 +90,7 @@ instance ScottyError e => ScottyError (ActionError e) where
     stringError = ActionError . stringError
     showError (Redirect url)  = url
     showError Next            = pack "Next"
+    showError Finish          = pack "Finish"
     showError (ActionError e) = showError e
 
 type ErrorHandler e m = Maybe (e -> ActionT e m ())

--- a/Web/Scotty/Internal/Types.hs
+++ b/Web/Scotty/Internal/Types.hs
@@ -107,7 +107,7 @@ data ActionEnv = Env { getReq       :: Request
                      , getFiles     :: [File]
                      }
 
-data RequestBodyState = BodyUntouched 
+data RequestBodyState = BodyUntouched
                       | BodyCached ByteString [BS.ByteString] -- whole body, chunks left to stream
                       | BodyCorrupted
 

--- a/Web/Scotty/Trans.hs
+++ b/Web/Scotty/Trans.hs
@@ -30,7 +30,7 @@ module Web.Scotty.Trans
       -- definition, as they completely replace the current 'Response' body.
     , text, html, file, json, stream, raw
       -- ** Exceptions
-    , raise, rescue, next, defaultHandler, ScottyError(..), liftAndCatchIO
+    , raise, rescue, next, finish, defaultHandler, ScottyError(..), liftAndCatchIO
       -- * Parsing Parameters
     , Param, Parsable(..), readEither
       -- * Types

--- a/test/Web/ScottySpec.hs
+++ b/test/Web/ScottySpec.hs
@@ -144,6 +144,15 @@ spec = do
         it "doesn't override a previously set Content-Type header" $ do
           get "/scotty" `shouldRespondWith` 200 {matchHeaders = ["Content-Type" <:> "text/somethingweird"]}
 
+    describe "finish" $ do
+      withApp (Scotty.get "/scotty" $ finish) $ do
+        it "responds with 200 by default" $ do
+          get "/scotty" `shouldRespondWith` 200
+
+      withApp (Scotty.get "/scotty" $ status status400 >> finish >> status status200) $ do
+        it "stops the execution of an action" $ do
+          get "/scotty" `shouldRespondWith` 400
+
 -- Unix sockets not available on Windows
 #if !defined(mingw32_HOST_OS)
   describe "scottySocket" .
@@ -168,4 +177,3 @@ withServer actions inner = E.bracket
   (\sock -> close sock >> removeFile socketPath)
   (\sock -> withAsync (Scotty.scottySocket def sock actions) $ const inner)
 #endif
-


### PR DESCRIPTION
Add `finish` function.

It finishes the execution of the current action. Like throwing an uncatchable exception. Any code after the call to finish will not be run.

See #186.