### PR TITLE
ignore invalid UTF-8 byte sequences in post parameters

### DIFF
--- a/Web/Scotty/Util.hs
+++ b/Web/Scotty/Util.hs
@@ -20,6 +20,7 @@ import Network.HTTP.Types
 import qualified Data.ByteString as B
 import qualified Data.Text.Lazy as T
 import qualified Data.Text.Encoding as ES
+import qualified Data.Text.Encoding.Error as ES
 
 import Web.Scotty.Internal.Types
 
@@ -27,7 +28,7 @@ lazyTextToStrictByteString :: T.Text -> B.ByteString
 lazyTextToStrictByteString = ES.encodeUtf8 . T.toStrict
 
 strictByteStringToLazyText :: B.ByteString -> T.Text
-strictByteStringToLazyText = T.fromStrict . ES.decodeUtf8
+strictByteStringToLazyText = T.fromStrict . ES.decodeUtf8With ES.lenientDecode
 
 setContent :: Content -> ScottyResponse -> ScottyResponse
 setContent c sr = sr { srContent = c }

--- a/test/Web/ScottySpec.hs
+++ b/test/Web/ScottySpec.hs
@@ -109,6 +109,9 @@ spec = do
           it "returns POST parameter with given name" $ do
             request "POST" "/search" [("Content-Type","application/x-www-form-urlencoded")] "query=haskell" `shouldRespondWith` "haskell"
 
+          it "replaces non UTF-8 bytes with Unicode replacement character" $ do
+            request "POST" "/search" [("Content-Type","application/x-www-form-urlencoded")] "query=\xe9" `shouldRespondWith` "\xfffd"
+
     describe "text" $ do
       let modernGreekText :: IsString a => a
           modernGreekText = "νέα ελληνικά"


### PR DESCRIPTION
* Scotty automatically decodes from parameters in POST requests' body to UTF-8
* This decoding occurs outside any exception handler, which leads to potential server crash
* This PR proposes a simple workaround replacing invalid bytes by standard replacement character