### PR TITLE
Add MonadThrow and MonadCatch instances for ActionT.

### DIFF
--- a/scotty.cabal
+++ b/scotty.cabal
@@ -74,6 +74,7 @@ Library
                        bytestring          >= 0.10.0.2 && < 0.11,
                        case-insensitive    >= 1.0.0.1  && < 1.3,
                        data-default-class  >= 0.0.1    && < 0.1,
+                       exceptions          >= 0.8      && < 0.9,
                        fail,
                        http-types          >= 0.8.2    && < 0.10,
                        monad-control       >= 1.0.0.3  && < 1.1,

--- a/scotty.cabal
+++ b/scotty.cabal
@@ -74,7 +74,7 @@ Library
                        bytestring          >= 0.10.0.2 && < 0.11,
                        case-insensitive    >= 1.0.0.1  && < 1.3,
                        data-default-class  >= 0.0.1    && < 0.1,
-                       exceptions          >= 0.8      && < 0.9,
+                       exceptions          >= 0.7      && < 0.9,
                        fail,
                        http-types          >= 0.8.2    && < 0.10,
                        monad-control       >= 1.0.0.3  && < 1.1,


### PR DESCRIPTION
Using `catch` and `throwM` on ActionT directly makes for much more readable
code than monad-control:

    lift (somethingThatMayFail >> text "success")
        `catch` (\(e :: IOException) -> text "file does not exist")
        `catch` (\(e :: SomeException) -> text "internal error")

Versus,

    st <- liftWith $ \run ->
        (somethingThatMayFail >> run (text "success"))
        `catch` (\(e :: IOException) -> run (text "file does not exist"))
        `catch` (\(e :: SomeException) -> run (text "internal error"))
    restoreT st