### PR TITLE
Add paramMaybe function

### DIFF
--- a/Web/Scotty.hs
+++ b/Web/Scotty.hs
@@ -17,7 +17,7 @@ module Web.Scotty
       -- ** Route Patterns
     , capture, regex, function, literal
       -- ** Accessing the Request, Captures, and Query Parameters
-    , request, header, headers, body, bodyReader, param, params, jsonData, files
+    , request, header, headers, body, bodyReader, param, paramMaybe, params, jsonData, files
       -- ** Modifying the Response and Redirecting
     , status, addHeader, setHeader, redirect
       -- ** Setting Response Body
@@ -186,6 +186,17 @@ jsonData = Trans.jsonData
 --   capture cannot be parsed.
 param :: Trans.Parsable a => Text -> ActionM a
 param = Trans.param
+
+-- | Look up a parameter. Similar behavior as 'param', except that it will
+-- return 'Nothing' instead of raising an exception.
+--
+--  * Returns 'Just' the parameter if the parameter is found.
+--
+--  * Returns 'Nothing' if parameter is not found.
+--
+-- * If parameter is found, but 'read' fails to parse to the correct type, 'next' is called.
+paramMaybe :: Trans.Parsable a => Text -> ActionM (Maybe a)
+paramMaybe = Trans.paramMaybe
 
 -- | Get all parameters from capture, form and query (in that order).
 params :: ActionM [Param]

--- a/Web/Scotty/Trans.hs
+++ b/Web/Scotty/Trans.hs
@@ -21,7 +21,7 @@ module Web.Scotty.Trans
       -- ** Route Patterns
     , capture, regex, function, literal
       -- ** Accessing the Request, Captures, and Query Parameters
-    , request, header, headers, body, bodyReader, param, params, jsonData, files
+    , request, header, headers, body, bodyReader, param, paramMaybe, params, jsonData, files
       -- ** Modifying the Response and Redirecting
     , status, addHeader, setHeader, redirect
       -- ** Setting Response Body


### PR DESCRIPTION
Hey guys, I have copied here a function `paramMaybe` that I am using on my project, and that is pretty handy:

``` haskell
paramMaybe :: Trans.Parsable a => Text -> ActionM (Maybe a)
```

When looking up a parameter with `paramMaybe` instead of `param`, a missing parameter does not throw an exception but returns 'Nothing'. This is great for switch-like parameters or parameters with defaults.

I am actually using a slightly different version that does not call `next` if the parsing fails. This one is closer to `param`. Let me know how well you think it fits in Scotty's ecosystem, no hard feeling if this gets rejected.

PS: couldn't find any meaningful test to add that wouldn't be trivially testing `Maybe` or `lookup`. Let me know if you think of anything.
