### PR TITLE
Cleanup settings

### DIFF
--- a/Web/Scotty/Internal/Types.hs
+++ b/Web/Scotty/Internal/Types.hs
@@ -34,7 +34,7 @@ import           Network.HTTP.Types
 
 import           Network.Wai hiding (Middleware, Application)
 import qualified Network.Wai as Wai
-import           Network.Wai.Handler.Warp (Settings, defaultSettings, setFdCacheDuration)
+import           Network.Wai.Handler.Warp (Settings, defaultSettings)
 import           Network.Wai.Parse (FileInfo)
 
 --------------------- Options -----------------------
@@ -49,7 +49,7 @@ data Options = Options { verbose :: Int -- ^ 0 = silent, 1(def) = startup banner
                        }
 
 instance Default Options where
-    def = Options 1 (setFdCacheDuration 0 defaultSettings)
+    def = Options 1 defaultSettings 
 
 ----- Transformer Aware Applications/Middleware -----
 type Middleware m = Application m -> Application m

--- a/scotty.cabal
+++ b/scotty.cabal
@@ -88,7 +88,7 @@ Library
                        transformers-compat >= 0.4      && < 0.6,
                        wai                 >= 3.0.0    && < 3.3,
                        wai-extra           >= 3.0.0    && < 3.1,
-                       warp                >= 3.0.0    && < 3.3
+                       warp                >= 3.0.13   && < 3.3
 
   GHC-options: -Wall -fno-warn-orphans
 


### PR DESCRIPTION
The default `fdCacheDuration` for `warp` is 0 as of 3.0.0: https://hackage.haskell.org/package/warp-3.2.12/docs/src/Network-Wai-Handler-Warp.html#setFdCacheDuration

No reason to re-set it; just noticed the redundancy.