### PR TITLE
Fix hlint error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ import Web.Scotty
 
 import Data.Monoid (mconcat)
 
-main = scotty 3000 $ do
+main = scotty 3000 $
     get "/:word" $ do
         beam <- param "word"
         html $ mconcat ["<h1>Scotty, ", beam, " me up!</h1>"]


### PR DESCRIPTION
The Haskell linter hlint is complaining about:
"Warning: Redundant do
Found:
  do get "/:word" $"

"Why not:
  get "/:word" $"

Since many editors have linting capabilities enable by default nowadays, it might be a good choice to follow the linting rules in the simple example, it also avoids confusion for Haskell beginners.