### PR TITLE
Add MonadReader and MonadState ActionT instances

### DIFF
--- a/Web/Scotty/Internal/Types.hs
+++ b/Web/Scotty/Internal/Types.hs
@@ -197,6 +197,18 @@ instance (ScottyError e, MonadBaseControl b m) => MonadBaseControl b (ActionT e 
     liftBaseWith = defaultLiftBaseWith
     restoreM     = defaultRestoreM
 
+instance (MonadReader r m, ScottyError e) => MonadReader r (ActionT e m) where
+    {-# INLINE ask #-}
+    ask = lift ask
+    {-# INLINE local #-}
+    local f = ActionT . mapExceptT (mapReaderT (mapStateT $ local f)) . runAM
+
+instance (MonadState s m, ScottyError e) => MonadState s (ActionT e m) where
+    {-# INLINE get #-}
+    get = lift get
+    {-# INLINE put #-}
+    put = lift . put
+
 ------------------ Scotty Routes --------------------
 data RoutePattern = Capture   Text
                   | Literal   Text

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+## 0.11.6 [2019.12.09]
+* Provide `MonadReader` and `MonadState` instances for `ActionT`.
+
 ## 0.11.5 [2019.09.07]
 * Allow building the test suite with `hspec-wai-0.10`.
 

--- a/scotty.cabal
+++ b/scotty.cabal
@@ -1,5 +1,5 @@
 Name:                scotty
-Version:             0.11.5
+Version:             0.11.6
 Synopsis:            Haskell web framework inspired by Ruby's Sinatra, using WAI and Warp
 Homepage:            https://github.com/scotty-web/scotty
 Bug-reports:         https://github.com/scotty-web/scotty/issues
@@ -72,7 +72,7 @@ Library
   default-language:    Haskell2010
   build-depends:       aeson                 >= 0.6.2.1  && < 1.5,
                        base                  >= 4.6      && < 5,
-                       base-compat-batteries >= 0.11     && < 0.12,
+                       base-compat-batteries >= 0.10     && < 0.12,
                        blaze-builder         >= 0.3.3.0  && < 0.5,
                        bytestring            >= 0.10.0.2 && < 0.11,
                        case-insensitive      >= 1.0.0.1  && < 1.3,


### PR DESCRIPTION
It's probably a fairly common case to have a MonadReader as 'm' in
'ActionT e m' which stores some global configuration. Accessing this
reader can only be done with explicit 'lift'.

This commit add 'MonadReader (ActionT e m)' instance which is forwarded
from 'm' itself, to avoid this 'lift' and simplify user code. The same
is done for 'MonadState'.