### PR TITLE
Use base-compat{-batteries}

### DIFF
--- a/Web/Scotty/Action.hs
+++ b/Web/Scotty/Action.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP               #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes        #-}
 module Web.Scotty.Action
@@ -37,7 +36,7 @@ import           Blaze.ByteString.Builder   (fromLazyByteString)
 
 import qualified Control.Exception          as E
 import           Control.Monad.Error.Class
-import           Control.Monad.Reader
+import           Control.Monad.Reader       hiding (mapM)
 import qualified Control.Monad.State        as MS
 import           Control.Monad.Trans.Except
 
@@ -47,9 +46,6 @@ import qualified Data.ByteString.Lazy.Char8 as BL
 import qualified Data.CaseInsensitive       as CI
 import           Data.Default.Class         (def)
 import           Data.Int
-#if !(MIN_VERSION_base(4,8,0))
-import           Data.Monoid                (mconcat)
-#endif
 import qualified Data.Text                  as ST
 import qualified Data.Text.Lazy             as T
 import           Data.Text.Lazy.Encoding    (encodeUtf8)
@@ -59,6 +55,9 @@ import           Network.HTTP.Types
 import           Network.Wai
 
 import           Numeric.Natural
+
+import           Prelude ()
+import           Prelude.Compat
 
 import           Web.Scotty.Internal.Types
 import           Web.Scotty.Util

--- a/Web/Scotty/Internal/Types.hs
+++ b/Web/Scotty/Internal/Types.hs
@@ -23,9 +23,6 @@ import           Control.Monad.Trans.Except
 import qualified Data.ByteString as BS
 import           Data.ByteString.Lazy.Char8 (ByteString)
 import           Data.Default.Class (Default, def)
-#if !(MIN_VERSION_base(4,8,0))
-import           Data.Monoid (mempty)
-#endif
 import           Data.String (IsString(..))
 import           Data.Text.Lazy (Text, pack)
 import           Data.Typeable (Typeable)
@@ -36,6 +33,9 @@ import           Network.Wai hiding (Middleware, Application)
 import qualified Network.Wai as Wai
 import           Network.Wai.Handler.Warp (Settings, defaultSettings)
 import           Network.Wai.Parse (FileInfo)
+
+import           Prelude ()
+import           Prelude.Compat
 
 --------------------- Options -----------------------
 data Options = Options { verbose :: Int -- ^ 0 = silent, 1(def) = startup banner

--- a/Web/Scotty/Route.hs
+++ b/Web/Scotty/Route.hs
@@ -14,9 +14,6 @@ import qualified Control.Monad.State as MS
 import qualified Data.ByteString.Char8 as B
 import qualified Data.ByteString.Lazy.Char8 as BL
 import           Data.Maybe (fromMaybe, isJust)
-#if !(MIN_VERSION_base(4,8,0))
-import           Data.Monoid (mconcat)
-#endif
 import           Data.String (fromString)
 import qualified Data.Text.Lazy as T
 import qualified Data.Text as TS
@@ -27,6 +24,9 @@ import           Network.Wai (Request(..))
 import           Network.Wai.Internal (getRequestBodyChunk)
 #endif
 import qualified Network.Wai.Parse as Parse hiding (parseRequestBody)
+
+import           Prelude ()
+import           Prelude.Compat
 
 import qualified Text.Regex as Regex
 

--- a/Web/Scotty/Util.hs
+++ b/Web/Scotty/Util.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 module Web.Scotty.Util
     ( lazyTextToStrictByteString
     , strictByteStringToLazyText

--- a/examples/basic.hs
+++ b/examples/basic.hs
@@ -7,14 +7,14 @@ import Network.Wai.Middleware.RequestLogger -- install wai-extra if you don't ha
 
 import Control.Monad
 import Control.Monad.Trans
-import Data.Monoid
 import System.Random (newStdGen, randomRs)
 
 import Network.HTTP.Types (status302)
 
 import Data.Text.Lazy.Encoding (decodeUtf8)
 import Data.String (fromString)
-import Prelude
+import Prelude ()
+import Prelude.Compat
 
 main :: IO ()
 main = scotty 3000 $ do

--- a/examples/exceptions.hs
+++ b/examples/exceptions.hs
@@ -3,13 +3,13 @@ module Main (main) where
 
 import Control.Monad.IO.Class
 
-import Data.Monoid
 import Data.String (fromString)
 
 import Network.HTTP.Types
 import Network.Wai.Middleware.RequestLogger
 
-import Prelude
+import Prelude ()
+import Prelude.Compat
 
 import System.Random
 

--- a/examples/globalstate.hs
+++ b/examples/globalstate.hs
@@ -9,7 +9,6 @@
 -- embedded into any MonadIO monad.
 module Main (main) where
 
-import Control.Applicative
 import Control.Concurrent.STM
 import Control.Monad.Reader
 
@@ -19,7 +18,8 @@ import Data.Text.Lazy (Text)
 
 import Network.Wai.Middleware.RequestLogger
 
-import Prelude
+import Prelude ()
+import Prelude.Compat
 
 import Web.Scotty.Trans
 

--- a/examples/reader.hs
+++ b/examples/reader.hs
@@ -7,11 +7,11 @@
 -}
 module Main where
 
-import Control.Applicative
 import Control.Monad.Reader (MonadIO, MonadReader, ReaderT, asks, lift, runReaderT)
 import Data.Default.Class (def)
 import Data.Text.Lazy (Text, pack)
-import Prelude
+import Prelude ()
+import Prelude.Compat
 import Web.Scotty.Trans (ScottyT, get, scottyOptsT, text)
 
 data Config = Config

--- a/examples/scotty-examples.cabal
+++ b/examples/scotty-examples.cabal
@@ -27,6 +27,7 @@ executable scotty-basic
   default-language:    Haskell2010
   hs-source-dirs:      .
   build-depends:       base >= 4.6 && < 5,
+                       base-compat >= 0.11 && < 0.12,
                        http-types,
                        mtl,
                        random,
@@ -65,6 +66,7 @@ executable scotty-exceptions
   default-language:    Haskell2010
   hs-source-dirs:      .
   build-depends:       base >= 4.6 && < 5,
+                       base-compat >= 0.11 && < 0.12,
                        http-types,
                        random,
                        scotty,
@@ -77,6 +79,7 @@ executable scotty-globalstate
   default-language:    Haskell2010
   hs-source-dirs:      .
   build-depends:       base >= 4.6 && < 5,
+                       base-compat >= 0.11 && < 0.12,
                        data-default-class,
                        mtl,
                        scotty,
@@ -111,6 +114,7 @@ executable scotty-reader
   default-language:    Haskell2010
   hs-source-dirs:      .
   build-depends:       base >= 4.6 && < 5,
+                       base-compat >= 0.11 && < 0.12,
                        data-default-class,
                        mtl,
                        scotty,
@@ -122,6 +126,7 @@ executable scotty-upload
   default-language:    Haskell2010
   hs-source-dirs:      .
   build-depends:       base >= 4.6 && < 5,
+                       base-compat >= 0.11 && < 0.12,
                        blaze-html,
                        bytestring,
                        filepath,
@@ -136,6 +141,7 @@ executable scotty-urlshortener
   default-language:    Haskell2010
   hs-source-dirs:      .
   build-depends:       base >= 4.6 && < 5,
+                       base-compat >= 0.11 && < 0.12,
                        blaze-html,
                        containers,
                        scotty,

--- a/examples/upload.hs
+++ b/examples/upload.hs
@@ -4,7 +4,6 @@ module Main (main) where
 import Web.Scotty
 
 import Control.Monad.IO.Class
-import Data.Monoid
 
 import Network.Wai.Middleware.RequestLogger
 import Network.Wai.Middleware.Static
@@ -17,7 +16,8 @@ import Text.Blaze.Html.Renderer.Text (renderHtml)
 import qualified Data.ByteString.Lazy as B
 import qualified Data.ByteString.Char8 as BS
 import System.FilePath ((</>))
-import Prelude
+import Prelude ()
+import Prelude.Compat
 
 main :: IO ()
 main = scotty 3000 $ do

--- a/examples/urlshortener.hs
+++ b/examples/urlshortener.hs
@@ -6,13 +6,13 @@ import Web.Scotty
 import Control.Concurrent.MVar
 import Control.Monad.IO.Class
 import qualified Data.Map as M
-import Data.Monoid
 import qualified Data.Text.Lazy as T
 
 import Network.Wai.Middleware.RequestLogger
 import Network.Wai.Middleware.Static
 
-import Prelude
+import Prelude ()
+import Prelude.Compat
 
 import qualified Text.Blaze.Html5 as H
 import Text.Blaze.Html5.Attributes

--- a/scotty.cabal
+++ b/scotty.cabal
@@ -70,27 +70,28 @@ Library
                        Web.Scotty.Route
                        Web.Scotty.Util
   default-language:    Haskell2010
-  build-depends:       aeson               >= 0.6.2.1  && < 1.5,
-                       base                >= 4.6      && < 5,
-                       blaze-builder       >= 0.3.3.0  && < 0.5,
-                       bytestring          >= 0.10.0.2 && < 0.11,
-                       case-insensitive    >= 1.0.0.1  && < 1.3,
-                       data-default-class  >= 0.0.1    && < 0.2,
-                       exceptions          >= 0.7      && < 0.11,
+  build-depends:       aeson                 >= 0.6.2.1  && < 1.5,
+                       base                  >= 4.6      && < 5,
+                       base-compat-batteries >= 0.11     && < 0.12,
+                       blaze-builder         >= 0.3.3.0  && < 0.5,
+                       bytestring            >= 0.10.0.2 && < 0.11,
+                       case-insensitive      >= 1.0.0.1  && < 1.3,
+                       data-default-class    >= 0.0.1    && < 0.2,
+                       exceptions            >= 0.7      && < 0.11,
                        fail,
-                       http-types          >= 0.8.2    && < 0.13,
-                       monad-control       >= 1.0.0.3  && < 1.1,
-                       mtl                 >= 2.1.2    && < 2.3,
-                       nats                >= 0.1      && < 2,
-                       network             >= 2.6.0.2  && < 3.2,
-                       regex-compat        >= 0.95.1   && < 0.96,
-                       text                >= 0.11.3.1 && < 1.3,
-                       transformers        >= 0.3.0.0  && < 0.6,
-                       transformers-base   >= 0.4.1    && < 0.5,
-                       transformers-compat >= 0.4      && < 0.7,
-                       wai                 >= 3.0.0    && < 3.3,
-                       wai-extra           >= 3.0.0    && < 3.1,
-                       warp                >= 3.0.13   && < 3.4
+                       http-types            >= 0.8.2    && < 0.13,
+                       monad-control         >= 1.0.0.3  && < 1.1,
+                       mtl                   >= 2.1.2    && < 2.3,
+                       nats                  >= 0.1      && < 2,
+                       network               >= 2.6.0.2  && < 3.2,
+                       regex-compat          >= 0.95.1   && < 0.96,
+                       text                  >= 0.11.3.1 && < 1.3,
+                       transformers          >= 0.3.0.0  && < 0.6,
+                       transformers-base     >= 0.4.1    && < 0.5,
+                       transformers-compat   >= 0.4      && < 0.7,
+                       wai                   >= 3.0.0    && < 3.3,
+                       wai-extra             >= 3.0.0    && < 3.1,
+                       warp                  >= 3.0.13   && < 3.4
 
   GHC-options: -Wall -fno-warn-orphans
 


### PR DESCRIPTION
This lets us get rid of some CPP in various places.

The examples only require `base-compat`, but I opted to use `base-compat-batteries` for the library itself since it will be required in #236.