### PR TITLE
Depend on fail and nats only on old GHC

### DIFF
--- a/scotty.cabal
+++ b/scotty.cabal
@@ -79,11 +79,9 @@ Library
                        case-insensitive      >= 1.0.0.1  && < 1.3,
                        data-default-class    >= 0.0.1    && < 0.2,
                        exceptions            >= 0.7      && < 0.11,
-                       fail,
                        http-types            >= 0.9.1    && < 0.13,
                        monad-control         >= 1.0.0.3  && < 1.1,
                        mtl                   >= 2.1.2    && < 2.3,
-                       nats                  >= 0.1      && < 2,
                        network               >= 2.6.0.2  && < 3.2,
                        regex-compat          >= 0.95.1   && < 0.96,
                        text                  >= 0.11.3.1 && < 1.3,
@@ -93,6 +91,12 @@ Library
                        wai                   >= 3.0.0    && < 3.3,
                        wai-extra             >= 3.0.0    && < 3.2,
                        warp                  >= 3.0.13   && < 3.4
+
+  if impl(ghc < 8.0)
+    build-depends:     fail
+
+  if impl(ghc < 7.10)
+    build-depends:     nats                  >= 0.1      && < 2
 
   GHC-options: -Wall -fno-warn-orphans
 


### PR DESCRIPTION
They are not needed on new GHCs.