### PR TITLE
Adding a max request size restriction for endpoints

### DIFF
--- a/Web/Scotty.hs
+++ b/Web/Scotty.hs
@@ -13,7 +13,7 @@ module Web.Scotty
       -- | 'Middleware' and routes are run in the order in which they
       -- are defined. All middleware is run first, followed by the first
       -- route that matches. If no route matches, a 404 response is given.
-    , middleware, get, post, put, delete, patch, options, addroute, matchAny, notFound
+    , middleware, get, post, put, delete, patch, options, addroute, matchAny, notFound, setMaxRequestBodySize
       -- ** Route Patterns
     , capture, regex, function, literal
       -- ** Accessing the Request, Captures, and Query Parameters
@@ -30,7 +30,7 @@ module Web.Scotty
       -- * Parsing Parameters
     , Param, Trans.Parsable(..), Trans.readEither
       -- * Types
-    , ScottyM, ActionM, RoutePattern, File
+    , ScottyM, ActionM, RoutePattern, File, Kilobytes
     ) where
 
 -- With the exception of this, everything else better just import types.
@@ -46,7 +46,7 @@ import Network.Socket (Socket)
 import Network.Wai (Application, Middleware, Request, StreamingBody)
 import Network.Wai.Handler.Warp (Port)
 
-import Web.Scotty.Internal.Types (ScottyT, ActionT, Param, RoutePattern, Options, File)
+import Web.Scotty.Internal.Types (ScottyT, ActionT, Param, RoutePattern, Options, File, Kilobytes)
 
 type ScottyM = ScottyT Text IO
 type ActionM = ActionT Text IO
@@ -88,6 +88,12 @@ defaultHandler = Trans.defaultHandler
 -- on the response). Every middleware is run on each request.
 middleware :: Middleware -> ScottyM ()
 middleware = Trans.middleware
+
+-- | Set global size limit for the request body. Requests with body size exceeding the limit will not be
+-- processed and an HTTP response 413 will be returned to the client. Size limit needs to be greater than 0, 
+-- otherwise the application will terminate on start. 
+setMaxRequestBodySize :: Kilobytes -> ScottyM ()
+setMaxRequestBodySize = Trans.setMaxRequestBodySize
 
 -- | Throw an exception, which can be caught with 'rescue'. Uncaught exceptions
 -- turn into HTTP 500 responses.

--- a/Web/Scotty/Internal/Types.hs
+++ b/Web/Scotty/Internal/Types.hs
@@ -5,11 +5,14 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
-module Web.Scotty.Internal.Types where
+{-# LANGUAGE RecordWildCards #-}
 
+module Web.Scotty.Internal.Types where      
+      
 import           Blaze.ByteString.Builder (Builder)
 
 import           Control.Applicative
+import           Control.Exception (Exception)
 import qualified Control.Exception as E
 import           Control.Monad.Base (MonadBase, liftBase, liftBaseDefault)
 import           Control.Monad.Catch (MonadCatch, catch, MonadThrow, throwM)
@@ -51,6 +54,13 @@ data Options = Options { verbose :: Int -- ^ 0 = silent, 1(def) = startup banner
 instance Default Options where
     def = Options 1 defaultSettings
 
+newtype RouteOptions = RouteOptions { maxRequestBodySize :: Maybe Kilobytes -- max allowed request size in KB
+                                    }
+
+instance Default RouteOptions where
+    def = RouteOptions Nothing
+
+type Kilobytes = Int
 ----- Transformer Aware Applications/Middleware -----
 type Middleware m = Application m -> Application m
 type Application m = Request -> m Response
@@ -60,10 +70,11 @@ data ScottyState e m =
     ScottyState { middlewares :: [Wai.Middleware]
                 , routes :: [Middleware m]
                 , handler :: ErrorHandler e m
+                , routeOptions :: RouteOptions
                 }
 
 instance Default (ScottyState e m) where
-    def = ScottyState [] [] Nothing
+    def = ScottyState [] [] Nothing def
 
 addMiddleware :: Wai.Middleware -> ScottyState e m -> ScottyState e m
 addMiddleware m s@(ScottyState {middlewares = ms}) = s { middlewares = m:ms }
@@ -73,6 +84,11 @@ addRoute r s@(ScottyState {routes = rs}) = s { routes = r:rs }
 
 addHandler :: ErrorHandler e m -> ScottyState e m -> ScottyState e m
 addHandler h s = s { handler = h }
+
+updateMaxRequestBodySize :: RouteOptions -> ScottyState e m -> ScottyState e m
+updateMaxRequestBodySize RouteOptions { .. } s@ScottyState { routeOptions = ro } = 
+    let ro' = ro { maxRequestBodySize = maxRequestBodySize } 
+    in s { routeOptions = ro' }
 
 newtype ScottyT e m a = ScottyT { runS :: State (ScottyState e m) a }
     deriving ( Functor, Applicative, Monad )
@@ -103,6 +119,10 @@ instance ScottyError e => ScottyError (ActionError e) where
     showError (ActionError _ e) = showError e
 
 type ErrorHandler e m = Maybe (e -> ActionT e m ())
+
+data ScottyException = RequestException BS.ByteString Status deriving (Show, Typeable)
+
+instance Exception ScottyException
 
 ------------------ Scotty Actions -------------------
 type Param = (Text, Text)

--- a/Web/Scotty/Util.hs
+++ b/Web/Scotty/Util.hs
@@ -9,14 +9,19 @@ module Web.Scotty.Util
     , add
     , addIfNotPresent
     , socketDescription
+    , readRequestBody
     ) where
 
 import Network.Socket (SockAddr(..), Socket, getSocketName, socketPort)
 import Network.Wai
 
+import Control.Monad (when)
+import Control.Exception (throw)
+
 import Network.HTTP.Types
 
 import qualified Data.ByteString as B
+import qualified Data.Text as TP (pack)
 import qualified Data.Text.Lazy as T
 import qualified Data.Text.Encoding as ES
 import qualified Data.Text.Encoding.Error as ES
@@ -70,3 +75,19 @@ socketDescription sock = do
   case sockName of
     SockAddrUnix u -> return $ "unix socket " ++ u
     _              -> fmap (\port -> "port " ++ show port) $ socketPort sock
+
+-- return request body or throw an exception if request body too big
+readRequestBody :: IO B.ByteString -> ([B.ByteString] -> IO [B.ByteString]) -> Maybe Kilobytes ->IO [B.ByteString]
+readRequestBody rbody prefix maxSize = do
+  b <- rbody
+  if B.null b then
+       prefix []
+    else
+      do
+        checkBodyLength maxSize 
+        readRequestBody rbody (prefix . (b:)) maxSize
+    where checkBodyLength :: Maybe Kilobytes ->  IO ()
+          checkBodyLength (Just maxSize') = prefix [] >>= \bodySoFar -> when (isBigger bodySoFar maxSize') readUntilEmpty
+          checkBodyLength Nothing = return ()
+          isBigger bodySoFar maxSize' = (B.length . B.concat $ bodySoFar) > maxSize' * 1024
+          readUntilEmpty = rbody >>= \b -> if B.null b then throw (RequestException (ES.encodeUtf8 . TP.pack $ "Request is too big Jim!") status413) else readUntilEmpty


### PR DESCRIPTION
This commit adds the following:

- a maxRequestSize function to set max request size
- RouteOptions where different global scotty options could located
  (max-size, rate etc.)
- ScottyState is extended by RouteOptions so it is available when
  processing requests

Commit does not break existing API and is backwards compatible.

Trying to address issue #203  