### PR TITLE
Allow building with `text-2.0`

### DIFF
--- a/scotty.cabal
+++ b/scotty.cabal
@@ -85,7 +85,7 @@ Library
                        mtl                   >= 2.1.2    && < 2.4,
                        network               >= 2.6.0.2  && < 3.2,
                        regex-compat          >= 0.95.1   && < 0.96,
-                       text                  >= 0.11.3.1 && < 1.3,
+                       text                  >= 0.11.3.1 && < 2.1,
                        transformers          >= 0.3.0.0  && < 0.7,
                        transformers-base     >= 0.4.1    && < 0.5,
                        transformers-compat   >= 0.4      && < 0.8,

--- a/test/Web/ScottySpec.hs
+++ b/test/Web/ScottySpec.hs
@@ -122,7 +122,7 @@ spec = do
       withApp (Scotty.setMaxRequestBodySize 1 >> Scotty.matchAny "/upload" (do status status200)) $ do
         it "upload endpoint for max-size requests, status 413 if request is too big, 200 otherwise" $ do
           request "POST" "/upload" [("Content-Type","multipart/form-data; boundary=--33")]
-            (TLE.encodeUtf8 . TL.pack . concat $ [show c | c <- ([1..1500]::[Integer])]) `shouldRespondWith` 413
+            (TLE.encodeUtf8 . TL.pack . concat $ [show c | c <- ([1..4500]::[Integer])]) `shouldRespondWith` 413
           request "POST" "/upload" [("Content-Type","multipart/form-data; boundary=--33")]
             (TLE.encodeUtf8 . TL.pack . concat $ [show c | c <- ([1..50]::[Integer])]) `shouldRespondWith` 200
 


### PR DESCRIPTION
For the most part, this is simply a matter of raising the upper version bounds in the `.cabal` file. The max-size request test case in the test suite needed to be adjusted, as it needs to pick a sufficiently large request such that it takes multiple chunks to store it as a lazy `Text` value. With `text-2.0` or later, the amount of ASCII characters that a single chunk can store is much larger due to using UTF-8 encoding internally, so we must generate a larger request to compensate.