### PR TITLE
Fix a Windows build error in the test suite

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,7 @@
 ## next [????.??.??]
+
+## 0.12.1 [2022.11.17]
+* Fix CPP bug that prevented tests from building on Windows.
 * Allow building with `transformers-0.6.*` and `mtl-2.3.*`. Because the
   `MonadTrans t` class gained a `forall m. Monad m => Monad (t m)` superclass
   in `transformers-0.6.0.0`, the `MonadTrans` and `MonadTransControl` instances

--- a/scotty.cabal
+++ b/scotty.cabal
@@ -1,5 +1,5 @@
 Name:                scotty
-Version:             0.12
+Version:             0.12.1
 Synopsis:            Haskell web framework inspired by Ruby's Sinatra, using WAI and Warp
 Homepage:            https://github.com/scotty-web/scotty
 Bug-reports:         https://github.com/scotty-web/scotty/issues

--- a/test/Web/ScottySpec.hs
+++ b/test/Web/ScottySpec.hs
@@ -36,6 +36,7 @@ availableMethods = [GET, POST, HEAD, PUT, PATCH, DELETE, OPTIONS]
 
 spec :: Spec
 spec = do
+  let withApp = with . scottyApp
   describe "ScottyM" $ do
     forM_ [
         ("GET", Scotty.get, get)
@@ -185,8 +186,6 @@ spec = do
   where ok, no :: ByteString
         ok = "HTTP/1.1 200 OK"
         no = "HTTP/1.1 404 Not Found"
-
-        withApp = with . scottyApp
 
 socketPath :: FilePath
 socketPath = "/tmp/scotty-test.socket"


### PR DESCRIPTION
The definition of `withApp` was mistakenly guarded behind CPP that is not reachable on Windows, but `withApp` is also needed outside of the CPP:

<details>

```
[1 of 2] Compiling Web.ScottySpec   ( test\Web\ScottySpec.hs, C:\\msys64\home\winferno\scotty\dist-newstyle\build\x86_64-windows\ghc-9.4.2\scotty-0.12\t\spec\build\spec\spec-tmp\Web\ScottySpec.o )

test\Web\ScottySpec.hs:49:9: error:
    Variable not in scope:
      withApp
        :: ScottyM ()
           -> SpecWith (st19, Network.Wai.Application)
           -> hspec-core-2.10.5:Test.Hspec.Core.Spec.Monad.SpecM () a9
   |
49 |         withApp (route "/scotty" $ html "") $ do
   |         ^^^^^^^

test\Web\ScottySpec.hs:53:9: error:
    Variable not in scope:
      withApp
        :: ScottyM ()
           -> SpecWith (st19, Network.Wai.Application)
           -> hspec-core-2.10.5:Test.Hspec.Core.Spec.Monad.SpecM () ()
   |
53 |         withApp (route "/scotty" $ html "") $ do
   |         ^^^^^^^

test\Web\ScottySpec.hs:59:9: error:
    Variable not in scope:
      withApp
        :: ScottyM ()
           -> SpecWith (st18, Network.Wai.Application)
           -> hspec-core-2.10.5:Test.Hspec.Core.Spec.Monad.SpecM () b0
   |
59 |         withApp (addroute method "/scotty" $ html "") $ do
   |         ^^^^^^^

test\Web\ScottySpec.hs:64:7: error:
    Variable not in scope:
      withApp
        :: ScottyM ()
           -> hspec-core-2.10.5:Test.Hspec.Core.Spec.Monad.SpecM
                (st17, Network.Wai.Application) ()
           -> SpecWith ()
   |
64 |       withApp (matchAny "/scotty" $ html "") $ do
   |       ^^^^^^^

test\Web\ScottySpec.hs:70:7: error:
    Variable not in scope:
      withApp
        :: ScottyM ()
           -> SpecWith (st16, Network.Wai.Application)
           -> hspec-core-2.10.5:Test.Hspec.Core.Spec.Monad.SpecM () a8
   |
70 |       withApp (notFound $ html "my custom not found page") $ do
   |       ^^^^^^^

test\Web\ScottySpec.hs:74:7: error:
    Variable not in scope:
      withApp
        :: ScottyM ()
           -> SpecWith (st15, Network.Wai.Application)
           -> hspec-core-2.10.5:Test.Hspec.Core.Spec.Monad.SpecM () a7
   |
74 |       withApp (notFound $ status status400 >> html "my custom not found page") $ do
   |       ^^^^^^^

test\Web\ScottySpec.hs:79:9: error:
    Variable not in scope:
      withApp
        :: m0 () -> SpecWith (st14, Network.Wai.Application) -> SpecWith ()
   |
79 |         withApp (return ()) $ do
   |         ^^^^^^^

test\Web\ScottySpec.hs:84:7: error:
    Variable not in scope:
      withApp
        :: Web.Scotty.Internal.Types.ScottyT TL.Text IO ()
           -> SpecWith (st13, Network.Wai.Application)
           -> hspec-core-2.10.5:Test.Hspec.Core.Spec.Monad.SpecM () a6
   |
84 |       withApp (defaultHandler text >> Scotty.get "/" (liftAndCatchIO $ E.throwIO E.DivideByZero)) $ do
   |       ^^^^^^^

test\Web\ScottySpec.hs:88:7: error:
    Variable not in scope:
      withApp
        :: Web.Scotty.Internal.Types.ScottyT TL.Text IO ()
           -> SpecWith (st12, Network.Wai.Application)
           -> hspec-core-2.10.5:Test.Hspec.Core.Spec.Monad.SpecM () a5
   |
88 |       withApp (defaultHandler (\_ -> status status503) >> Scotty.get "/" (liftAndCatchIO $ E.throwIO E.DivideByZero)) $ do
   |       ^^^^^^^

test\Web\ScottySpec.hs:93:9: error:
    Variable not in scope:
      withApp
        :: ScottyM ()
           -> SpecWith (st11, Network.Wai.Application) -> SpecWith ()
   |
93 |         withApp (Scotty.get "/" $ liftAndCatchIO $ E.throwIO E.DivideByZero) $ do
   |         ^^^^^^^

test\Web\ScottySpec.hs:98:5: error:
    Variable not in scope:
      withApp
        :: ScottyM ()
           -> SpecWith (st10, Network.Wai.Application)
           -> hspec-core-2.10.5:Test.Hspec.Core.Spec.Monad.SpecM () a4
   |
98 |     withApp (Scotty.get "/" $ (undefined `EL.catch` ((\_ -> html "") :: E.SomeException -> ActionM ()))) $ do
   |     ^^^^^^^

test\Web\ScottySpec.hs:102:5: error:
    Variable not in scope:
      withApp
        :: ScottyM ()
           -> SpecWith (st9, Network.Wai.Application)
           -> hspec-core-2.10.5:Test.Hspec.Core.Spec.Monad.SpecM () a3
    |
102 |     withApp (Scotty.get "/dictionary" $ empty <|> param "word1" <|> empty <|> param "word2" >>= text) $
    |     ^^^^^^^

test\Web\ScottySpec.hs:109:7: error:
    Variable not in scope:
      withApp
        :: ScottyM ()
           -> hspec-core-2.10.5:Test.Hspec.Core.Spec.Monad.SpecM
                (st8, Network.Wai.Application) ()
           -> SpecWith ()
    |
109 |       withApp (Scotty.matchAny "/search" $ param "query" >>= text) $ do
    |       ^^^^^^^

test\Web\ScottySpec.hs:122:7: error:
    Variable not in scope:
      withApp
        :: Web.Scotty.Internal.Types.ScottyT TL.Text IO ()
           -> SpecWith (st7, Network.Wai.Application) -> SpecWith ()
    |
122 |       withApp (Scotty.setMaxRequestBodySize 1 >> Scotty.matchAny "/upload" (do status status200)) $ do
    |       ^^^^^^^

test\Web\ScottySpec.hs:133:7: error:
    Variable not in scope:
      withApp
        :: ScottyM ()
           -> hspec-core-2.10.5:Test.Hspec.Core.Spec.Monad.SpecM
                (st6, Network.Wai.Application) ()
           -> hspec-core-2.10.5:Test.Hspec.Core.Spec.Monad.SpecM () a2
    |
133 |       withApp (Scotty.get "/scotty" $ text modernGreekText) $ do
    |       ^^^^^^^

test\Web\ScottySpec.hs:140:7: error:
    Variable not in scope:
      withApp
        :: ScottyM ()
           -> SpecWith (st5, Network.Wai.Application)
           -> hspec-core-2.10.5:Test.Hspec.Core.Spec.Monad.SpecM () ()
    |
140 |       withApp (Scotty.get "/scotty" $ setHeader "Content-Type" "text/somethingweird" >> text modernGreekText) $ do
    |       ^^^^^^^

test\Web\ScottySpec.hs:148:7: error:
    Variable not in scope:
      withApp
        :: ScottyM ()
           -> hspec-core-2.10.5:Test.Hspec.Core.Spec.Monad.SpecM
                (st4, Network.Wai.Application) ()
           -> hspec-core-2.10.5:Test.Hspec.Core.Spec.Monad.SpecM () a1
    |
148 |       withApp (Scotty.get "/scotty" $ html russianLanguageTextInHtml) $ do
    |       ^^^^^^^

test\Web\ScottySpec.hs:155:7: error:
    Variable not in scope:
      withApp
        :: ScottyM ()
           -> SpecWith (st3, Network.Wai.Application)
           -> hspec-core-2.10.5:Test.Hspec.Core.Spec.Monad.SpecM () ()
    |
155 |       withApp (Scotty.get "/scotty" $ setHeader "Content-Type" "text/somethingweird" >> html russianLanguageTextInHtml) $ do
    |       ^^^^^^^

test\Web\ScottySpec.hs:160:7: error:
    Variable not in scope:
      withApp
        :: ScottyM ()
           -> SpecWith (st2, Network.Wai.Application) -> SpecWith ()
    |
160 |       withApp (Scotty.get "/scotty" $ setHeader "Content-Type" "text/somethingweird" >> json (Just (5::Int))) $ do
    |       ^^^^^^^

test\Web\ScottySpec.hs:165:7: error:
    Variable not in scope:
      withApp
        :: ScottyM ()
           -> SpecWith (st1, Network.Wai.Application)
           -> hspec-core-2.10.5:Test.Hspec.Core.Spec.Monad.SpecM () a0
    |
165 |       withApp (Scotty.get "/scotty" $ finish) $ do
    |       ^^^^^^^

test\Web\ScottySpec.hs:169:7: error:
    Variable not in scope:
      withApp
        :: ScottyM ()
           -> SpecWith (st0, Network.Wai.Application)
           -> hspec-core-2.10.5:Test.Hspec.Core.Spec.Monad.SpecM () ()
    |
169 |       withApp (Scotty.get "/scotty" $ status status400 >> finish >> status status200) $ do
    |       ^^^^^^^
```
</details>