### PR TITLE
Allow building with aeson-2.2.*

### DIFF
--- a/scotty.cabal
+++ b/scotty.cabal
@@ -73,7 +73,7 @@ Library
                        Web.Scotty.Route
                        Web.Scotty.Util
   default-language:    Haskell2010
-  build-depends:       aeson                 >= 0.6.2.1  && < 2.2,
+  build-depends:       aeson                 >= 0.6.2.1  && < 2.3,
                        base                  >= 4.6      && < 5,
                        base-compat-batteries >= 0.10     && < 0.14,
                        blaze-builder         >= 0.3.3.0  && < 0.5,


### PR DESCRIPTION
None of the API changes in `aeson-2.2.0.0` impact how `scotty` uses `aeson`, so it is safe to simply raise the upper version bounds.