### PR TITLE
Fix handling of encoded slash in url path

### DIFF
--- a/Web/Scotty/Route.hs
+++ b/Web/Scotty/Route.hs
@@ -115,7 +115,7 @@ matchRoute :: RoutePattern -> Request -> Maybe [Param]
 matchRoute (Literal pat)  req | pat == path req = Just []
                               | otherwise       = Nothing
 matchRoute (Function fun) req = fun req
-matchRoute (Capture pat)  req = go (T.split (=='/') pat) (compress $ T.split (=='/') $ path req) []
+matchRoute (Capture pat)  req = go (T.split (=='/') pat) (compress $ T.fromStrict <$> "":pathInfo req) [] -- add empty segment to simulate being at the root
     where go [] [] prs = Just prs -- request string and pattern match!
           go [] r  prs | T.null (mconcat r)  = Just prs -- in case request has trailing slashes
                        | otherwise           = Nothing  -- request string is longer than pattern

--- a/Web/Scotty/Route.hs
+++ b/Web/Scotty/Route.hs
@@ -113,7 +113,7 @@ matchRoute :: RoutePattern -> Request -> Maybe [Param]
 matchRoute (Literal pat)  req | pat == path req = Just []
                               | otherwise       = Nothing
 matchRoute (Function fun) req = fun req
-matchRoute (Capture pat)  req = go (T.split (=='/') pat) (compress $ T.fromStrict <$> "":pathInfo req) [] -- add empty segment to simulate being at the root
+matchRoute (Capture pat)  req = go (T.split (=='/') pat) (compress $ "":pathInfo req) [] -- add empty segment to simulate being at the root
     where go [] [] prs = Just prs -- request string and pattern match!
           go [] r  prs | T.null (mconcat r)  = Just prs -- in case request has trailing slashes
                        | otherwise           = Nothing  -- request string is longer than pattern

--- a/test/Web/ScottySpec.hs
+++ b/test/Web/ScottySpec.hs
@@ -56,7 +56,7 @@ spec = do
           it ("properly handles extra slash routes for " ++ method ++ " requests") $ do
             makeRequest "//scotty" `shouldRespondWith` 200
 
-        withApp (route "/:paramName" $ param "paramName" >>= text) $ do
+        withApp (route "/:paramName" $ captureParam "paramName" >>= text) $ do
           it ("captures route parameters for " ++ method ++ " requests with url encoded '/' in path") $ do
             makeRequest "/a%2Fb" `shouldRespondWith` "a/b"
             

--- a/test/Web/ScottySpec.hs
+++ b/test/Web/ScottySpec.hs
@@ -56,6 +56,10 @@ spec = do
           it ("properly handles extra slash routes for " ++ method ++ " requests") $ do
             makeRequest "//scotty" `shouldRespondWith` 200
 
+        withApp (route "/:paramName" $ param "paramName" >>= text) $ do
+          it ("captures route parameters for " ++ method ++ " requests with url encoded '/' in path") $ do
+            makeRequest "/a%2Fb" `shouldRespondWith` "a/b"
+            
     describe "addroute" $ do
       forM_ availableMethods $ \method -> do
         withApp (addroute method "/scotty" $ html "") $ do


### PR DESCRIPTION
Currently url encoded forward slash is decoded before the routing logic is applied. This is a problem when we want to allow arbitrary user data to be passed as a path segment.

For example `/test/some%2Fdata/path` will be routed as `/test/some/data/path` it thus becomes impossible to have a forward slash in a captured path segment.

This fix bypasses the broken rountrip of `intercalate "/"` <-> `split (=='/')`
