### PR TITLE
disambiguate parameters (#204)

### DIFF
--- a/Web/Scotty.hs
+++ b/Web/Scotty.hs
@@ -243,12 +243,13 @@ params :: ActionM [Param]
 params = Trans.params
 {-# DEPRECATED params "(#204) Not a good idea to treat all parameters identically. Use captureParams, formParams and queryParams instead. "#-}
 
+-- | Get capture parameters
 captureParams :: ActionM [Param]
 captureParams = Trans.captureParams
-
+-- | Get form parameters
 formParams :: ActionM [Param]
 formParams = Trans.formParams
-
+-- | Get query parameters
 queryParams :: ActionM [Param]
 queryParams = Trans.queryParams
 

--- a/Web/Scotty.hs
+++ b/Web/Scotty.hs
@@ -214,12 +214,27 @@ param :: Trans.Parsable a => Text -> ActionM a
 param = Trans.param
 {-# DEPRECATED param "(#204) Not a good idea to treat all parameters identically. Use captureParam, formParam and queryParam instead. "#-}
 
+-- | Get a capture parameter.
+--
+-- * Raises an exception which can be caught by 'rescue' if parameter is not found. If the exception is not caught, scotty will return a HTTP error code 500 ("Internal Server Error") to the client.
+--
+-- * If the parameter is found, but 'parseParam' fails to parse to the correct type, 'next' is called.
 captureParam :: Trans.Parsable a => Text -> ActionM a
 captureParam = Trans.captureParam
 
+-- | Get a form parameter.
+--
+-- * Raises an exception which can be caught by 'rescue' if parameter is not found. If the exception is not caught, scotty will return a HTTP error code 400 ("Bad Request") to the client.
+--
+-- * This function raises a code 400 also if the parameter is found, but 'parseParam' fails to parse to the correct type.
 formParam :: Trans.Parsable a => Text -> ActionM a
 formParam = Trans.formParam
 
+-- | Get a query parameter.
+--
+-- * Raises an exception which can be caught by 'rescue' if parameter is not found. If the exception is not caught, scotty will return a HTTP error code 400 ("Bad Request") to the client.
+--
+-- * This function raises a code 400 also if the parameter is found, but 'parseParam' fails to parse to the correct type.
 queryParam :: Trans.Parsable a => Text -> ActionM a
 queryParam = Trans.queryParam
 

--- a/Web/Scotty.hs
+++ b/Web/Scotty.hs
@@ -17,7 +17,11 @@ module Web.Scotty
       -- ** Route Patterns
     , capture, regex, function, literal
       -- ** Accessing the Request, Captures, and Query Parameters
-    , request, header, headers, body, bodyReader, param, params, jsonData, files
+    , request, header, headers, body, bodyReader
+    , param, params
+    , captureParam, formParam, queryParam
+    , captureParams, formParams, queryParams
+    , jsonData, files
       -- ** Modifying the Response and Redirecting
     , status, addHeader, setHeader, redirect
       -- ** Setting Response Body
@@ -208,10 +212,31 @@ jsonData = Trans.jsonData
 --   capture cannot be parsed.
 param :: Trans.Parsable a => Text -> ActionM a
 param = Trans.param
+{-# DEPRECATED param "(#204) Not a good idea to treat all parameters identically. Use captureParam, formParam and queryParam instead. "#-}
+
+captureParam :: Trans.Parsable a => Text -> ActionM a
+captureParam = Trans.captureParam
+
+formParam :: Trans.Parsable a => Text -> ActionM a
+formParam = Trans.formParam
+
+queryParam :: Trans.Parsable a => Text -> ActionM a
+queryParam = Trans.queryParam
 
 -- | Get all parameters from capture, form and query (in that order).
 params :: ActionM [Param]
 params = Trans.params
+{-# DEPRECATED params "(#204) Not a good idea to treat all parameters identically. Use captureParams, formParams and queryParams instead. "#-}
+
+captureParams :: ActionM [Param]
+captureParams = Trans.captureParams
+
+formParams :: ActionM [Param]
+formParams = Trans.formParams
+
+queryParams :: ActionM [Param]
+queryParams = Trans.queryParams
+
 
 -- | Set the HTTP response status. Default is 200.
 status :: Status -> ActionM ()

--- a/Web/Scotty/Action.hs
+++ b/Web/Scotty/Action.hs
@@ -248,7 +248,7 @@ param k = do
 --
 -- * Raises an exception which can be caught by 'rescue' if parameter is not found. If the exception is not caught, scotty will return a HTTP error code 500 ("Internal Server Error") to the client.
 --
--- * If parameter is found, but 'parseParam' fails to parse to the correct type, 'next' is called.
+-- * If the parameter is found, but 'parseParam' fails to parse to the correct type, 'next' is called.
 captureParam :: (Parsable a, ScottyError e, Monad m) => T.Text -> ActionT e m a
 captureParam = paramWith CaptureParam getCaptureParams status500
 
@@ -256,7 +256,7 @@ captureParam = paramWith CaptureParam getCaptureParams status500
 --
 -- * Raises an exception which can be caught by 'rescue' if parameter is not found. If the exception is not caught, scotty will return a HTTP error code 400 ("Bad Request") to the client.
 --
--- * If parameter is found, but 'parseParam' fails to parse to the correct type, 'next' is called.
+-- * This function raises a code 400 also if the parameter is found, but 'parseParam' fails to parse to the correct type.
 formParam :: (Parsable a, ScottyError e, Monad m) => T.Text -> ActionT e m a
 formParam = paramWith FormParam getFormParams status400
 
@@ -264,7 +264,7 @@ formParam = paramWith FormParam getFormParams status400
 --
 -- * Raises an exception which can be caught by 'rescue' if parameter is not found. If the exception is not caught, scotty will return a HTTP error code 400 ("Bad Request") to the client.
 --
--- * If parameter is found, but 'parseParam' fails to parse to the correct type, 'next' is called.
+-- * This function raises a code 400 also if the parameter is found, but 'parseParam' fails to parse to the correct type.
 queryParam :: (Parsable a, ScottyError e, Monad m) => T.Text -> ActionT e m a
 queryParam = paramWith QueryParam getQueryParams status400
 

--- a/Web/Scotty/Action.hs
+++ b/Web/Scotty/Action.hs
@@ -17,7 +17,13 @@ module Web.Scotty.Action
     , jsonData
     , next
     , param
+    , captureParam
+    , formParam
+    , queryParam
     , params
+    , captureParams
+    , formParams
+    , queryParams
     , raise
     , raiseStatus
     , raw
@@ -226,19 +232,70 @@ jsonData = do
 --
 -- * Raises an exception which can be caught by 'rescue' if parameter is not found.
 --
--- * If parameter is found, but 'read' fails to parse to the correct type, 'next' is called.
+-- * If parameter is found, but 'parseParam' fails to parse to the correct type, 'next' is called.
 --   This means captures are somewhat typed, in that a route won't match if a correctly typed
 --   capture cannot be parsed.
 param :: (Parsable a, ScottyError e, Monad m) => T.Text -> ActionT e m a
-param k = do
-    val <- ActionT $ liftM (lookup k . getParams) ask
+param = paramWith "" getParams status500
+{-# DEPRECATED param "(#204) Not a good idea to treat all parameters identically. Use captureParam, formParam and queryParam instead. "#-}
+
+-- | Get a capture parameter.
+--
+-- * Raises an exception which can be caught by 'rescue' if parameter is not found. If the exception is not caught, scotty will return a HTTP error code 500 ("Internal Server Error") to the client.
+--
+-- * If parameter is found, but 'parseParam' fails to parse to the correct type, 'next' is called.
+captureParam :: (Parsable a, ScottyError e, Monad m) => T.Text -> ActionT e m a
+captureParam = paramWith "Capture" getCaptureParams status500
+
+-- | Get a form parameter.
+--
+-- * Raises an exception which can be caught by 'rescue' if parameter is not found. If the exception is not caught, scotty will return a HTTP error code 400 ("Bad Request") to the client.
+--
+-- * If parameter is found, but 'parseParam' fails to parse to the correct type, 'next' is called.
+formParam :: (Parsable a, ScottyError e, Monad m) => T.Text -> ActionT e m a
+formParam = paramWith "Form" getFormParams status400
+
+-- | Get a query parameter.
+--
+-- * Raises an exception which can be caught by 'rescue' if parameter is not found. If the exception is not caught, scotty will return a HTTP error code 400 ("Bad Request") to the client.
+--
+-- * If parameter is found, but 'parseParam' fails to parse to the correct type, 'next' is called.
+queryParam :: (Parsable a, ScottyError e, Monad m) => T.Text -> ActionT e m a
+queryParam = paramWith "Query" getQueryParams status400
+
+paramWith :: (ScottyError e, Monad m, Parsable b) =>
+             String -- ^ String representation of the type of query parameter
+          -> (ActionEnv -> [Param])
+          -> Status -- ^ HTTP status to return if parameter is not found
+          -> T.Text -- ^ parameter name
+          -> ActionT e m b
+paramWith tys f err k = do
+    val <- ActionT $ liftM (lookup k . f) ask
     case val of
-        Nothing -> raise $ stringError $ "Param: " ++ T.unpack k ++ " not found!"
+        Nothing -> raiseStatus err $ stringError (tys <> " parameter: " ++ T.unpack k ++ " not found!")
         Just v  -> either (const next) return $ parseParam v
 
 -- | Get all parameters from capture, form and query (in that order).
 params :: Monad m => ActionT e m [Param]
-params = ActionT $ liftM getParams ask
+params = paramsWith getParams
+{-# DEPRECATED params "(#204) Not a good idea to treat all parameters identically. Use captureParams, formParams and queryParams instead. "#-}
+
+-- | Get capture parameters
+captureParams :: Monad m => ActionT e m [Param]
+captureParams = paramsWith getCaptureParams
+-- | Get form parameters
+formParams :: Monad m => ActionT e m [Param]
+formParams = paramsWith getFormParams
+-- | Get query parameters
+queryParams :: Monad m => ActionT e m [Param]
+queryParams = paramsWith getQueryParams
+
+paramsWith :: Monad m => (ActionEnv -> a) -> ActionT e m a
+paramsWith f = ActionT (f <$> ask)
+
+{-# DEPRECATED getParams "(#204) Not a good idea to treat all parameters identically" #-}
+getParams :: ActionEnv -> [Param]
+getParams e = getCaptureParams e <> getFormParams e <> getQueryParams e
 
 -- | Minimum implemention: 'parseParam'
 class Parsable a where

--- a/Web/Scotty/Internal/Types.hs
+++ b/Web/Scotty/Internal/Types.hs
@@ -134,7 +134,9 @@ type Param = (Text, Text)
 type File = (Text, FileInfo ByteString)
 
 data ActionEnv = Env { getReq       :: Request
-                     , getParams    :: [Param]
+                     , getCaptureParams :: [Param]
+                     , getFormParams    :: [Param]
+                     , getQueryParams :: [Param]
                      , getBody      :: IO ByteString
                      , getBodyChunk :: IO BS.ByteString
                      , getFiles     :: [File]

--- a/Web/Scotty/Route.hs
+++ b/Web/Scotty/Route.hs
@@ -196,10 +196,11 @@ mkEnv req captures opts = do
 
     let
         convert (k, v) = (strictByteStringToLazyText k, strictByteStringToLazyText v)
-        parameters =  captures ++ map convert formparams ++ queryparams
+        formparams' = map convert formparams
+        -- parameters =  captures ++ map convert formparams ++ queryparams
         queryparams = parseEncodedParams $ rawQueryString req
 
-    return $ Env req parameters bs safeBodyReader [ (strictByteStringToLazyText k, fi) | (k,fi) <- fs ]
+    return $ Env req captures formparams' queryparams bs safeBodyReader [ (strictByteStringToLazyText k, fi) | (k,fi) <- fs ]
 
 parseEncodedParams :: B.ByteString -> [Param]
 parseEncodedParams bs = [ (T.fromStrict k, T.fromStrict $ fromMaybe "" v) | (k,v) <- parseQueryText bs ]

--- a/Web/Scotty/Route.hs
+++ b/Web/Scotty/Route.hs
@@ -197,7 +197,6 @@ mkEnv req captures opts = do
     let
         convert (k, v) = (strictByteStringToLazyText k, strictByteStringToLazyText v)
         formparams' = map convert formparams
-        -- parameters =  captures ++ map convert formparams ++ queryparams
         queryparams = parseEncodedParams $ rawQueryString req
 
     return $ Env req captures formparams' queryparams bs safeBodyReader [ (strictByteStringToLazyText k, fi) | (k,fi) <- fs ]

--- a/Web/Scotty/Trans.hs
+++ b/Web/Scotty/Trans.hs
@@ -21,7 +21,11 @@ module Web.Scotty.Trans
       -- ** Route Patterns
     , capture, regex, function, literal
       -- ** Accessing the Request, Captures, and Query Parameters
-    , request, header, headers, body, bodyReader, param, params, jsonData, files
+    , request, header, headers, body, bodyReader
+    , param, params
+    , captureParam, formParam, queryParam
+    , captureParams, formParams, queryParams
+    , jsonData, files
       -- ** Modifying the Response and Redirecting
     , status, addHeader, setHeader, redirect
       -- ** Setting Response Body

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 ## next [????.??.??]
 * Adds a new `nested` handler that allows you to place an entire WAI Application under a Scotty route
+* Disambiguate request parameters (#204). Adjust the `Env` type to have three [Param] fields instead of one, add `captureParam`, `formParam`, `queryParam` and the associated `captureParams`, `formParams`, `queryParams`. Add deprecation notices to `param` and `params`.
 
 ## 0.12.1 [2022.11.17]
 * Fix CPP bug that prevented tests from building on Windows.

--- a/examples/basic.hs
+++ b/examples/basic.hs
@@ -32,7 +32,7 @@ main = scotty 3000 $ do
     -- Using a parameter in the query string. If it has
     -- not been given, a 500 page is generated.
     get "/foo" $ do
-        v <- param "fooparam"
+        v <- captureParam "fooparam"
         html $ mconcat ["<h1>", v, "</h1>"]
 
     -- An uncaught error becomes a 500 page.
@@ -58,7 +58,7 @@ main = scotty 3000 $ do
     -- any string, and capture that value as a parameter.
     -- URL captures take precedence over query string parameters.
     get "/foo/:bar/required" $ do
-        v <- param "bar"
+        v <- captureParam "bar"
         html $ mconcat ["<h1>", v, "</h1>"]
 
     -- Files are streamed directly to the client.
@@ -75,7 +75,7 @@ main = scotty 3000 $ do
         json $ take 20 $ randomRs (1::Int,100) g
 
     get "/ints/:is" $ do
-        is <- param "is"
+        is <- captureParam "is"
         json $ [(1::Int)..10] ++ is
 
     get "/setbody" $ do

--- a/examples/cookies.hs
+++ b/examples/cookies.hs
@@ -33,7 +33,7 @@ main = scotty 3000 $ do
                 H.input H.! type_ "submit" H.! value "set a cookie"
 
     post "/set-a-cookie" $ do
-        name'  <- param "name"
-        value' <- param "value"
+        name'  <- captureParam "name"
+        value' <- captureParam "value"
         setSimpleCookie name' value'
         redirect "/"

--- a/examples/exceptions.hs
+++ b/examples/exceptions.hs
@@ -53,7 +53,7 @@ main = scottyT 3000 id $ do -- note, we aren't using any additional transformer 
                        ]
 
     get "/switch/:val" $ do
-        v <- param "val"
+        v <- captureParam "val"
         _ <- if even v then raise Forbidden else raise (NotFound v)
         text "this will never be reached"
 

--- a/examples/urlshortener.hs
+++ b/examples/urlshortener.hs
@@ -42,17 +42,17 @@ main = do
                         H.input H.! type_ "submit"
 
     post "/shorten" $ do
-        url <- param "url"
+        url <- captureParam "url"
         liftIO $ modifyMVar_ m $ \(i,db) -> return (i+1, M.insert i (T.pack url) db)
         redirect "/list"
 
     -- We have to be careful here, because this route can match pretty much anything.
     -- Thankfully, the type system knows that 'hash' must be an Int, so this route
-    -- only matches if 'read' can successfully parse the hash capture as an Int.
+    -- only matches if 'parseParam' can successfully parse the hash capture as an Int.
     -- Otherwise, the pattern match will fail and Scotty will continue matching
     -- subsequent routes.
     get "/:hash" $ do
-        hash <- param "hash"
+        hash <- captureParam "hash"
         (_,db) <- liftIO $ readMVar m
         case M.lookup hash db of
             Nothing -> raise $ mconcat ["URL hash #", T.pack $ show $ hash, " not found in database!"]

--- a/test/Web/ScottySpec.hs
+++ b/test/Web/ScottySpec.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, CPP #-}
+{-# LANGUAGE OverloadedStrings, CPP, ScopedTypeVariables #-}
 module Web.ScottySpec (main, spec) where
 
 import           Test.Hspec
@@ -112,12 +112,10 @@ spec = do
       withApp (
         do
           Scotty.matchAny "/search/:q" $ do
-            v <- captureParam "q"
-            let y = v :: Int
+            _ :: Int <- captureParam "q"
             text "int"
           Scotty.matchAny "/search/:q" $ do
-            v <- captureParam "q"
-            let y = v :: String
+            _ :: String <- captureParam "q"
             text "string"
               ) $ do
         it "responds with 200 OK iff at least one route match at the right type" $ do
@@ -129,8 +127,8 @@ spec = do
             v <- captureParam "q"
             json (v :: Int)
               ) $ do
-        it "responds with 500 Server Error if no route matches at the right type" $ do
-          get "/search/potato" `shouldRespondWith` 500
+        it "responds with 404 Not Found if no route matches at the right type" $ do
+          get "/search/potato" `shouldRespondWith` 404
 
     describe "queryParam" $ do
       withApp (Scotty.matchAny "/search" $ queryParam "query" >>= text) $ do

--- a/test/Web/ScottySpec.hs
+++ b/test/Web/ScottySpec.hs
@@ -102,23 +102,23 @@ spec = do
       it "has a MonadBaseControl instance" $ do
         get "/" `shouldRespondWith` 200
 
-    withApp (Scotty.get "/dictionary" $ empty <|> param "word1" <|> empty <|> param "word2" >>= text) $
+    withApp (Scotty.get "/dictionary" $ empty <|> queryParam "word1" <|> empty <|> queryParam "word2" >>= text) $
       it "has an Alternative instance" $ do
         get "/dictionary?word1=haskell"   `shouldRespondWith` "haskell"
         get "/dictionary?word2=scotty"    `shouldRespondWith` "scotty"
         get "/dictionary?word1=a&word2=b" `shouldRespondWith` "a"
 
-    describe "param" $ do
-      withApp (Scotty.matchAny "/search" $ param "query" >>= text) $ do
+    describe "queryParam" $ do
+      withApp (Scotty.matchAny "/search" $ queryParam "query" >>= text) $ do
         it "returns query parameter with given name" $ do
           get "/search?query=haskell" `shouldRespondWith` "haskell"
 
-        context "when used with application/x-www-form-urlencoded data" $ do
-          it "returns POST parameter with given name" $ do
-            request "POST" "/search" [("Content-Type","application/x-www-form-urlencoded")] "query=haskell" `shouldRespondWith` "haskell"
-
-          it "replaces non UTF-8 bytes with Unicode replacement character" $ do
-            request "POST" "/search" [("Content-Type","application/x-www-form-urlencoded")] "query=\xe9" `shouldRespondWith` "\xfffd"
+    describe "formParam" $ do
+      withApp (Scotty.matchAny "/search" $ formParam "query" >>= text) $ do
+        it "returns form parameter with given name" $ do
+          request "POST" "/search" [("Content-Type","application/x-www-form-urlencoded")] "query=haskell" `shouldRespondWith` "haskell"
+        it "replaces non UTF-8 bytes with Unicode replacement character" $ do
+          request "POST" "/search" [("Content-Type","application/x-www-form-urlencoded")] "query=\xe9" `shouldRespondWith` "\xfffd"
 
 
     describe "requestLimit" $ do

--- a/test/Web/ScottySpec.hs
+++ b/test/Web/ScottySpec.hs
@@ -118,7 +118,7 @@ spec = do
             _ :: String <- captureParam "q"
             text "string"
               ) $ do
-        it "responds with 200 OK iff at least one route match at the right type" $ do
+        it "responds with 200 OK iff at least one route matches at the right type" $ do
           get "/search/42" `shouldRespondWith` 200 { matchBody = "int" }
           get "/search/potato" `shouldRespondWith` 200 { matchBody = "string" }
       withApp (
@@ -129,6 +129,14 @@ spec = do
               ) $ do
         it "responds with 404 Not Found if no route matches at the right type" $ do
           get "/search/potato" `shouldRespondWith` 404
+      withApp (
+        do
+          Scotty.matchAny "/search/:q" $ do
+            v <- captureParam "zzz"
+            json (v :: Int)
+              ) $ do
+        it "responds with 500 Server Error if the parameter cannot be found in the capture" $ do
+          get "/search/potato" `shouldRespondWith` 500
 
     describe "queryParam" $ do
       withApp (Scotty.matchAny "/search" $ queryParam "query" >>= text) $ do


### PR DESCRIPTION
Disambiguate request parameters (#204). 

* Adjust the `Env` type to have three [Param] fields instead of one
* add `captureParam`, `formParam`, `queryParam` and the associated `captureParams`, `formParams`, `queryParams`. 
* Add deprecation notices to `param` and `params`
* adjust examples and tests