### PR TITLE
WIP Files limit #203

### DIFF
--- a/Web/Scotty.hs
+++ b/Web/Scotty.hs
@@ -46,7 +46,7 @@ import Network.Socket (Socket)
 import Network.Wai (Application, Middleware, Request, StreamingBody)
 import Network.Wai.Handler.Warp (Port)
 
-import Web.Scotty.Internal.Types (ScottyT, ActionT, Param, RoutePattern, Options, File, Kilobytes)
+import Web.Scotty.Internal.Types (ScottyT, ActionT, Param, RoutePattern, Options, File, FileMem, Kilobytes)
 
 type ScottyM = ScottyT Text IO
 type ActionM = ActionT Text IO
@@ -174,7 +174,7 @@ request :: ActionM Request
 request = Trans.request
 
 -- | Get list of uploaded files.
-files :: ActionM [File]
+files :: ActionM [FileMem]
 files = Trans.files
 
 -- | Get a request header. Header name is case-insensitive.

--- a/Web/Scotty/Action.hs
+++ b/Web/Scotty/Action.hs
@@ -165,8 +165,8 @@ request :: Monad m => ActionT e m Request
 request = ActionT $ liftM getReq ask
 
 -- | Get list of uploaded files.
-files :: Monad m => ActionT e m [File]
-files = ActionT $ liftM getFiles ask
+files :: Monad m => ActionT e m [FileMem]
+files = ActionT $ liftM getFilesMem ask
 
 -- | Get a request header. Header name is case-insensitive.
 header :: (ScottyError e, Monad m) => T.Text -> ActionT e m (Maybe T.Text)

--- a/Web/Scotty/Internal/Types.hs
+++ b/Web/Scotty/Internal/Types.hs
@@ -131,13 +131,17 @@ instance Exception ScottyException
 ------------------ Scotty Actions -------------------
 type Param = (Text, Text)
 
-type File = (Text, FileInfo ByteString)
+-- type File = (Text, FileInfo (Either ByteString FilePath))
+type File i = (Text, FileInfo i)
+type FileMem = File ByteString
+type FileDisk = File FilePath
 
 data ActionEnv = Env { getReq       :: Request
                      , getParams    :: [Param]
                      , getBody      :: IO ByteString
                      , getBodyChunk :: IO BS.ByteString
-                     , getFiles     :: [File]
+                     , getFilesMem  :: [FileMem]
+                     , getFilesDisk :: [FileDisk]
                      }
 
 data RequestBodyState = BodyUntouched

--- a/Web/Scotty/Internal/Types.hs
+++ b/Web/Scotty/Internal/Types.hs
@@ -139,8 +139,8 @@ data ActionEnv = Env { getReq       :: Request
                      , getParams    :: [Param]
                      , getBody      :: IO ByteString
                      , getBodyChunk :: IO BS.ByteString
-                     , getFilesMem  :: [FileMem]
-                     , getFilesDisk :: [FileDisk]
+                     , getFilesMem  :: [FileMem] -- ^ files that are completely in memory
+                     , getFilesDisk :: [FileDisk] -- ^ files that have been saved to disk
                      }
 
 data RequestBodyState = BodyUntouched

--- a/Web/Scotty/Internal/Types.hs
+++ b/Web/Scotty/Internal/Types.hs
@@ -131,7 +131,6 @@ instance Exception ScottyException
 ------------------ Scotty Actions -------------------
 type Param = (Text, Text)
 
--- type File = (Text, FileInfo (Either ByteString FilePath))
 type File i = (Text, FileInfo i)
 type FileMem = File ByteString
 type FileDisk = File FilePath

--- a/scotty.cabal
+++ b/scotty.cabal
@@ -87,6 +87,7 @@ Library
                        mtl                   >= 2.1.2    && < 2.4,
                        network               >= 2.6.0.2  && < 3.2,
                        regex-compat          >= 0.95.1   && < 0.96,
+                       resourcet             >= 0.4.6,
                        text                  >= 0.11.3.1 && < 2.1,
                        time                  >= 1.8,
                        transformers          >= 0.3.0.0  && < 0.7,


### PR DESCRIPTION
* parse request body according to request type : only URL-encoded payloads get parsed completely, multipart uploads (e.g. files) are limited (using a more restrictive default than the previous one : https://hackage.haskell.org/package/wai-extra-3.1.13.0/docs/Network-Wai-Parse.html#v:defaultParseRequestBodyOptions )
* use `resourcet` for dumping file uploads to temp files (WIP)