### PR TITLE
Request body is preserved across 'next' calls #147

### DIFF
--- a/Web/Scotty/Action.hs
+++ b/Web/Scotty/Action.hs
@@ -47,7 +47,7 @@ import           Blaze.ByteString.Builder   (fromLazyByteString)
 
 import qualified Control.Exception          as E
 import           Control.Monad              (liftM, when)
-import           Control.Monad.Error.Class
+import           Control.Monad.Error.Class (throwError, catchError)
 import           Control.Monad.IO.Class     (MonadIO(..))
 import           Control.Monad.Reader       (MonadReader(..), ReaderT(..))
 import qualified Control.Monad.State.Strict as MS

--- a/Web/Scotty/Body.hs
+++ b/Web/Scotty/Body.hs
@@ -1,0 +1,106 @@
+{-# LANGUAGE FlexibleContexts, FlexibleInstances, RecordWildCards,
+             OverloadedStrings, MultiWayIf #-}
+module Web.Scotty.Body (
+  newBodyInfo,
+  cloneBodyInfo
+
+  , getFormParamsAndFilesAction
+  , getBodyAction
+  , getBodyChunkAction
+  ) where
+
+import           Control.Concurrent.MVar
+import           Control.Monad.IO.Class
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as B
+import qualified Data.ByteString.Lazy.Char8 as BL
+import           Data.Maybe
+import           GHC.Exception
+import           Network.Wai (Request(..), getRequestBodyChunk)
+import qualified Network.Wai.Parse as Parse hiding (parseRequestBody)
+import           Web.Scotty.Action
+import           Web.Scotty.Internal.Types (BodyInfo(..), BodyChunkBuffer(..), BodyPartiallyStreamed(..))
+import           Web.Scotty.Util
+
+-- | Make a new BodyInfo with readProgress at 0 and an empty BodyChunkBuffer.
+newBodyInfo :: (MonadIO m) => Request -> m BodyInfo
+newBodyInfo req = liftIO $ do
+  readProgress <- newMVar 0
+  chunkBuffer <- newMVar (BodyChunkBuffer False [])
+  return $ BodyInfo readProgress chunkBuffer (getRequestBodyChunk req)
+
+-- | Make a copy of a BodyInfo, sharing the previous BodyChunkBuffer but with the
+-- readProgress MVar reset to 0.
+cloneBodyInfo :: (MonadIO m) => BodyInfo -> m BodyInfo
+cloneBodyInfo (BodyInfo _ chunkBufferVar getChunk) = liftIO $ do
+  cleanReadProgressVar <- newMVar 0
+  return $ BodyInfo cleanReadProgressVar chunkBufferVar getChunk
+
+-- | Get the form params and files from the request. Requires reading the whole body.
+getFormParamsAndFilesAction :: Request -> BodyInfo -> IO ([Param], [Parse.File BL.ByteString])
+getFormParamsAndFilesAction req bodyInfo = do
+  let shouldParseBody = isJust $ Parse.getRequestBodyType req
+
+  if shouldParseBody
+    then
+    do
+      bs <- getBodyAction bodyInfo
+      let wholeBody = BL.toChunks bs
+      (formparams, fs) <- parseRequestBody wholeBody Parse.lbsBackEnd req
+      let convert (k, v) = (strictByteStringToLazyText k, strictByteStringToLazyText v)
+      return (convert <$> formparams, fs)
+    else
+    return ([], [])
+
+-- | Retrieve the entire body, using the cached chunks in the BodyInfo and reading any other
+-- chunks if they still exist.
+-- Mimic the previous behavior by throwing BodyPartiallyStreamed if the user has already
+-- started reading the body by chunks.
+getBodyAction :: BodyInfo -> IO (BL.ByteString)
+getBodyAction (BodyInfo readProgress chunkBufferVar getChunk) =
+  modifyMVar readProgress $ \index ->
+    modifyMVar chunkBufferVar $ \bcb@(BodyChunkBuffer hasFinished chunks) -> do
+      if | index > 0 -> throw BodyPartiallyStreamed
+         | hasFinished -> return (bcb, (index, BL.fromChunks chunks))
+         | otherwise -> do
+             newChunks <- takeAll getChunk return
+             return $ (BodyChunkBuffer True (chunks ++ newChunks), (index, BL.fromChunks (chunks ++ newChunks)))
+
+-- | Retrieve a chunk from the body at the index stored in the readProgress MVar.
+-- Serve the chunk from the cached array if it's already present; otherwise read another
+-- chunk from WAI and advance the index.
+getBodyChunkAction :: BodyInfo -> IO BS.ByteString
+getBodyChunkAction (BodyInfo readProgress chunkBufferVar getChunk) =
+  modifyMVar readProgress $ \index ->
+    modifyMVar chunkBufferVar $ \bcb@(BodyChunkBuffer hasFinished chunks) -> do
+      if | index < length chunks -> return (bcb, (index + 1, chunks !! index))
+         | hasFinished -> return (bcb, (index, mempty))
+         | otherwise -> do
+             newChunk <- getChunk
+             return (BodyChunkBuffer (newChunk == mempty) (chunks ++ [newChunk]), (index + 1, newChunk))
+
+-- | Call getChunk repeatedly until it returns an empty chunk, and return a list of all the
+-- chunks read.
+takeAll :: (IO B.ByteString) -> ([B.ByteString] -> IO [B.ByteString]) -> IO [B.ByteString]
+takeAll getChunk prefix = getChunk >>= \b -> if B.null b then prefix [] else takeAll getChunk (prefix . (b:))
+
+
+-- Stolen from wai-extra's Network.Wai.Parse, modified to accept body as list of Bytestrings.
+-- Reason: WAI's requestBody is an IO action that returns the body as chunks. Once read,
+-- they can't be read again. We read them into a lazy Bytestring, so Scotty user can get
+-- the raw body, even if they also want to call wai-extra's parsing routines.
+parseRequestBody :: MonadIO m
+                 => [B.ByteString]
+                 -> Parse.BackEnd y
+                 -> Request
+                 -> m ([Parse.Param], [Parse.File y])
+parseRequestBody bl s r =
+    case Parse.getRequestBodyType r of
+        Nothing -> return ([], [])
+        Just rbt -> do
+            mvar <- liftIO $ newMVar bl -- MVar is a bit of a hack so we don't have to inline
+                                        -- large portions of Network.Wai.Parse
+            let provider = modifyMVar mvar $ \bsold -> case bsold of
+                                                []     -> return ([], B.empty)
+                                                (b:bs) -> return (bs, b)
+            liftIO $ Parse.sinkRequestBody s rbt provider

--- a/Web/Scotty/Internal/Types.hs
+++ b/Web/Scotty/Internal/Types.hs
@@ -70,6 +70,16 @@ type Kilobytes = Int
 type Middleware m = Application m -> Application m
 type Application m = Request -> m Response
 
+------------------ Scotty Request Body --------------------
+
+data BodyChunkBuffer = BodyChunkBuffer { hasFinishedReadingChunks :: Bool
+                                       , chunksReadSoFar :: [BS.ByteString] }
+
+data BodyInfo = BodyInfo { bodyInfoReadProgress :: MVar Int
+                         , bodyInfoChunkBuffer :: MVar BodyChunkBuffer
+                         , bodyInfoDirectChunkRead :: IO BS.ByteString
+                         }
+
 --------------- Scotty Applications -----------------
 
 data ScottyState e m =
@@ -287,12 +297,4 @@ instance IsString RoutePattern where
     fromString = Capture . pack
 
 
------------------- Scotty Request Body --------------------
 
-data BodyChunkBuffer = BodyChunkBuffer { hasFinishedReadingChunks :: Bool
-                                       , chunksReadSoFar :: [BS.ByteString] }
-
-data BodyInfo = BodyInfo { bodyInfoReadProgress :: MVar Int
-                         , bodyInfoChunkBuffer :: MVar BodyChunkBuffer
-                         , bodyInfoDirectChunkRead :: IO BS.ByteString
-                         }

--- a/Web/Scotty/Internal/Types.hs
+++ b/Web/Scotty/Internal/Types.hs
@@ -85,7 +85,6 @@ instance Default (ScottyState e m) where
 addMiddleware :: Wai.Middleware -> ScottyState e m -> ScottyState e m
 addMiddleware m s@(ScottyState {middlewares = ms}) = s { middlewares = m:ms }
 
--- addRoute :: Middleware m -> ScottyState e m -> ScottyState e m
 addRoute :: (BodyInfo -> Middleware m) -> ScottyState e m -> ScottyState e m
 addRoute r s@(ScottyState {routes = rs}) = s { routes = r:rs }
 

--- a/Web/Scotty/Internal/Types.hs
+++ b/Web/Scotty/Internal/Types.hs
@@ -12,6 +12,7 @@ module Web.Scotty.Internal.Types where
 import           Blaze.ByteString.Builder (Builder)
 
 import           Control.Applicative
+import Control.Concurrent.MVar
 import           Control.Exception (Exception)
 import qualified Control.Exception as E
 import qualified Control.Monad as Monad
@@ -283,3 +284,14 @@ data RoutePattern = Capture   Text
 
 instance IsString RoutePattern where
     fromString = Capture . pack
+
+
+------------------ Scotty Request Body --------------------
+
+data BodyChunkBuffer = BodyChunkBuffer { hasFinishedReadingChunks :: Bool
+                                       , chunksReadSoFar :: [BS.ByteString] }
+
+data BodyInfo = BodyInfo { bodyInfoReadProgress :: MVar Int
+                         , bodyInfoChunkBuffer :: MVar BodyChunkBuffer
+                         , bodyInfoDirectChunkRead :: IO BS.ByteString
+                         }

--- a/Web/Scotty/Internal/Types.hs
+++ b/Web/Scotty/Internal/Types.hs
@@ -71,12 +71,6 @@ type Middleware m = Application m -> Application m
 type Application m = Request -> m Response
 
 --------------- Scotty Applications -----------------
--- data ScottyState e m =
---     ScottyState { middlewares :: [Wai.Middleware]
---                 , routes :: [Middleware m]
---                 , handler :: ErrorHandler e m
---                 , routeOptions :: RouteOptions
---                 }
 
 data ScottyState e m =
     ScottyState { middlewares :: [Wai.Middleware]

--- a/Web/Scotty/Route.hs
+++ b/Web/Scotty/Route.hs
@@ -107,12 +107,6 @@ route opts h method pat action bodyInfo app req =
             Nothing -> tryNext
      else tryNext
 
--- evalAction :: (ScottyError e, Monad m) =>
---               ErrorHandler e m -> (Either ScottyException ActionEnv) -> ActionT e m () -> m (Maybe Response)
--- evalAction h eia action = case eia of
---   Left (RequestException msg s) -> return . Just $ responseBuilder s [("Content-Type","text/html")] $ fromByteString msg
---   Right env -> runAction h env action
-
 matchRoute :: RoutePattern -> Request -> Maybe [Param]
 matchRoute (Literal pat)  req | pat == path req = Just []
                               | otherwise       = Nothing

--- a/Web/Scotty/Trans.hs
+++ b/Web/Scotty/Trans.hs
@@ -62,6 +62,7 @@ import Web.Scotty.Route
 import Web.Scotty.Internal.Types hiding (Application, Middleware)
 import Web.Scotty.Util (socketDescription)
 import qualified Web.Scotty.Internal.Types as Scotty
+import Web.Scotty.Body (newBodyInfo)
 
 -- | Run a scotty application using the warp server.
 -- NB: scotty p === scottyT p id
@@ -108,7 +109,9 @@ scottyAppT :: (Monad m, Monad n)
            -> n Application
 scottyAppT runActionToIO defs = do
     let s = execState (runS defs) def
-    let rapp req callback = runActionToIO (foldl (flip ($)) notFoundApp (routes s) req) >>= callback
+    let rapp req callback = do
+          bodyInfo <- newBodyInfo req
+          runActionToIO (foldl (flip ($)) notFoundApp ([midd bodyInfo | midd <- routes s]) req) >>= callback
     return $ foldl (flip ($)) rapp (middlewares s)
 
 notFoundApp :: Monad m => Scotty.Application m

--- a/Web/Scotty/Util.hs
+++ b/Web/Scotty/Util.hs
@@ -95,9 +95,9 @@ readRequestBody rbody prefix maxSize = do
           checkBodyLength = \case
             Just maxSize' -> do
               bodySoFar <- prefix []
-              when (isBigger bodySoFar maxSize') readUntilEmpty
+              when (bodySoFar `isBigger` maxSize') readUntilEmpty
             Nothing -> return ()
-          isBigger bodySoFar maxSize' = (B.length . B.concat $ bodySoFar) > maxSize' * 1024
+          isBigger bodySoFar maxSize' = (B.length . B.concat $ bodySoFar) > maxSize' * 1024 -- XXX this looks both inefficient and wrong
           readUntilEmpty = do
             b <- rbody
             if B.null b

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 * Adds a new `nested` handler that allows you to place an entire WAI Application under a Scotty route
 * Disambiguate request parameters (#204). Adjust the `Env` type to have three [Param] fields instead of one, add `captureParam`, `formParam`, `queryParam` and the associated `captureParams`, `formParams`, `queryParams`. Add deprecation notices to `param` and `params`.
 * Add `Scotty.Cookie` module.
+* Change body parsing behaviour such that calls to 'next' don't result in POST request bodies disappearing (#147).
 
 ## 0.12.1 [2022.11.17]
 * Fix CPP bug that prevented tests from building on Windows.

--- a/scotty.cabal
+++ b/scotty.cabal
@@ -65,6 +65,7 @@ Library
                        Web.Scotty.Internal.Types
                        Web.Scotty.Cookie
   other-modules:       Web.Scotty.Action
+                       Web.Scotty.Body
                        Web.Scotty.Route
                        Web.Scotty.Util
   default-language:    Haskell2010

--- a/test/Web/ScottySpec.hs
+++ b/test/Web/ScottySpec.hs
@@ -164,6 +164,15 @@ spec = do
         it "responds with 400 Bad Request if the form parameter cannot be parsed at the right type" $ do
           request "POST" "/search" [("Content-Type","application/x-www-form-urlencoded")] "query=potato" `shouldRespondWith` 400
 
+      withApp (do
+                  Scotty.post "/first" $ next
+                  Scotty.post "/first" $ do
+                    p :: Int <- formParam "p"
+                    json p
+              ) $ do
+        it "preserves the body of a POST request even after 'next' (#147)" $ do
+          request "POST" "/first" [("Content-Type","application/x-www-form-urlencoded")] "p=42" `shouldRespondWith` "42"
+
 
     describe "requestLimit" $ do
       withApp (Scotty.setMaxRequestBodySize 1 >> Scotty.matchAny "/upload" (do status status200)) $ do


### PR DESCRIPTION
1. added test case to confirm issue is still there
2. adapted patch by @thomasjm https://github.com/scotty-web/scotty/pull/206/files to handle max body size parameter
3. clarify imports in a few places