### PR TITLE
Refactor ActionT to use ReaderT pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ A Haskell web framework inspired by Ruby's Sinatra, using WAI and Warp.
 {-# LANGUAGE OverloadedStrings #-}
 import Web.Scotty
 
-import Data.Monoid (mconcat)
-
 main = scotty 3000 $
     get "/:word" $ do
         beam <- captureParam "word"
@@ -41,7 +39,7 @@ Feel free to ask questions or report bugs on the [Github issue tracker](https://
 
 Github issues are now (September 2023) labeled, so newcomers to the Haskell language can start with `easy fix` ones and gradually progress to `new feature`s, `bug`s and `R&D` :)
 
-## Package version numbers
+## Package versions
 
 Scotty adheres to the [Package Versioning Policy](https://pvp.haskell.org/).
 
@@ -71,4 +69,4 @@ Scotty adheres to the [Package Versioning Policy](https://pvp.haskell.org/).
 
 
 # Copyright 
-(c) 2012-Present Andrew Farmer and Scotty contributors
+(c) 2012-Present, Andrew Farmer and Scotty contributors

--- a/Web/Scotty.hs
+++ b/Web/Scotty.hs
@@ -51,7 +51,8 @@ import Network.Socket (Socket)
 import Network.Wai (Application, Middleware, Request, StreamingBody)
 import Network.Wai.Handler.Warp (Port)
 
-import Web.Scotty.Internal.Types (ScottyT, ActionT, Handler(..), ErrorHandler, Param, RoutePattern, Options, defaultOptions, File, Kilobytes)
+import Web.Scotty.Internal.Types (ScottyT, ActionT, ErrorHandler, Param, RoutePattern, Options, defaultOptions, File, Kilobytes)
+import Web.Scotty.Exceptions (Handler(..))
 
 type ScottyM = ScottyT IO
 type ActionM = ActionT IO

--- a/Web/Scotty.hs
+++ b/Web/Scotty.hs
@@ -96,8 +96,6 @@ middleware = Trans.middleware
 -- this could require stripping the current prefix, or adding the prefix to your
 -- application's handlers if it depends on them. One potential use-case for this
 -- is hosting a web-socket handler under a specific route.
--- nested :: Application -> ActionM ()
--- nested :: (Monad m, MonadIO m) => Application -> ActionT Text m ()
 nested :: Application -> ActionM ()
 nested = Trans.nested
 
@@ -107,16 +105,23 @@ nested = Trans.nested
 setMaxRequestBodySize :: Kilobytes -> ScottyM ()
 setMaxRequestBodySize = Trans.setMaxRequestBodySize
 
--- | Throw a "500 Server Error" 'StatusError', which can be caught with 'rescue'. Uncaught exceptions
--- turn into HTTP 500 responses.
+-- | Throw a "500 Server Error" 'StatusError', which can be caught with 'rescue'.
+--
+-- Uncaught exceptions turn into HTTP 500 responses.
 raise :: Text -> ActionM a
 raise = Trans.raise
 
--- | Throw a 'StatusError' exception that has an associated HTTP error code and can be caught with 'rescue'. Uncaught exceptions turn into HTTP responses corresponding to the given status.
+-- | Throw a 'StatusError' exception that has an associated HTTP error code and can be caught with 'rescue'.
+--
+-- Uncaught exceptions turn into HTTP responses corresponding to the given status.
 raiseStatus :: Status -> Text -> ActionM a
 raiseStatus = Trans.raiseStatus
 
--- | Throw an exception. A user-defined 'Handler' will then have to define its interpretation and a translation to HTTP error codes.
+-- | Throw an exception which can be caught within the scope of the current Action with 'rescue' or 'catch'.
+--
+-- If the exception is not caught locally, another option is to implement a global 'Handler' (with 'defaultHandler') that defines its interpretation and a translation to HTTP error codes.
+--
+-- Uncaught exceptions turn into HTTP 500 responses.
 throw :: (E.Exception e) => e -> ActionM a
 throw = Trans.throw
 

--- a/Web/Scotty.hs
+++ b/Web/Scotty.hs
@@ -112,7 +112,7 @@ setMaxRequestBodySize = Trans.setMaxRequestBodySize
 raise :: Text -> ActionM a
 raise = Trans.raise
 
--- | Throw an exception that has an associated HTTP error code. Uncaught exceptions turn into HTTP responses corresponding to the given status.
+-- | Throw a 'StatusError' exception that has an associated HTTP error code and can be caught with 'rescue'. Uncaught exceptions turn into HTTP responses corresponding to the given status.
 raiseStatus :: Status -> Text -> ActionM a
 raiseStatus = Trans.raiseStatus
 
@@ -122,6 +122,9 @@ throw = Trans.throw
 
 -- | Abort execution of this action and continue pattern matching routes.
 -- Like an exception, any code after 'next' is not executed.
+--
+-- NB : Internally, this is implemented with an exception that can only be
+-- caught by the library, but not by the user.
 --
 -- As an example, these two routes overlap. The only way the second one will
 -- ever run is if the first one calls 'next'.
@@ -152,7 +155,7 @@ next = Trans.next
 finish :: ActionM a
 finish = Trans.finish
 
--- | Catch an exception.
+-- | Catch an exception e.g. a 'StatusError' or a user-defined exception.
 --
 -- > raise JustKidding `rescue` (\msg -> text msg)
 rescue :: E.Exception e => ActionM a -> (e -> ActionM a) -> ActionM a

--- a/Web/Scotty.hs
+++ b/Web/Scotty.hs
@@ -39,7 +39,6 @@ module Web.Scotty
     , ScottyState, defaultScottyState
     ) where
 
--- With the exception of this, everything else better just import types.
 import qualified Web.Scotty.Trans as Trans
 
 import qualified Control.Exception          as E

--- a/Web/Scotty.hs
+++ b/Web/Scotty.hs
@@ -148,7 +148,7 @@ finish = Trans.finish
 
 -- | Catch an exception thrown by 'raise'.
 --
--- > raise "just kidding" `rescue` (\msg -> text msg)
+-- > raise JustKidding `rescue` (\msg -> text msg)
 rescue :: E.Exception e => ActionM a -> (e -> ActionM a) -> ActionM a
 rescue = Trans.rescue
 

--- a/Web/Scotty.hs
+++ b/Web/Scotty.hs
@@ -35,6 +35,7 @@ module Web.Scotty
     , Param, Trans.Parsable(..), Trans.readEither
       -- * Types
     , ScottyM, ActionM, RoutePattern, File, Kilobytes, Handler(..)
+    , ScottyState, defaultScottyState
     ) where
 
 -- With the exception of this, everything else better just import types.
@@ -51,7 +52,7 @@ import Network.Socket (Socket)
 import Network.Wai (Application, Middleware, Request, StreamingBody)
 import Network.Wai.Handler.Warp (Port)
 
-import Web.Scotty.Internal.Types (ScottyT, ActionT, ErrorHandler, Param, RoutePattern, Options, defaultOptions, File, Kilobytes)
+import Web.Scotty.Internal.Types (ScottyT, ActionT, ErrorHandler, Param, RoutePattern, Options, defaultOptions, File, Kilobytes, ScottyState, defaultScottyState)
 import Web.Scotty.Exceptions (Handler(..))
 
 type ScottyM = ScottyT IO

--- a/Web/Scotty.hs
+++ b/Web/Scotty.hs
@@ -30,7 +30,7 @@ module Web.Scotty
       -- definition, as they completely replace the current 'Response' body.
     , text, html, file, json, stream, raw
       -- ** Exceptions
-    , raise, raiseStatus, rescue, next, finish, defaultHandler, liftAndCatchIO
+    , raise, raiseStatus, throw, rescue, next, finish, defaultHandler, liftAndCatchIO
       -- * Parsing Parameters
     , Param, Trans.Parsable(..), Trans.readEither
       -- * Types
@@ -106,14 +106,18 @@ nested = Trans.nested
 setMaxRequestBodySize :: Kilobytes -> ScottyM ()
 setMaxRequestBodySize = Trans.setMaxRequestBodySize
 
--- | Throw an exception, which can be caught with 'rescue'. Uncaught exceptions
+-- | Throw a "500 Server Error" 'StatusError', which can be caught with 'rescue'. Uncaught exceptions
 -- turn into HTTP 500 responses.
-raise :: E.Exception e => e -> ActionM a
+raise :: Text -> ActionM a
 raise = Trans.raise
 
--- | Throw an exception, which can be caught with 'rescue'. Uncaught exceptions turn into HTTP responses corresponding to the given status.
+-- | Throw an exception that has an associated HTTP error code. Uncaught exceptions turn into HTTP responses corresponding to the given status.
 raiseStatus :: Status -> Text -> ActionM a
 raiseStatus = Trans.raiseStatus
+
+-- | Throw an exception. A user-defined 'Handler' will then have to define its interpretation and a translation to HTTP error codes.
+throw :: (E.Exception e) => e -> ActionM a
+throw = Trans.throw
 
 -- | Abort execution of this action and continue pattern matching routes.
 -- Like an exception, any code after 'next' is not executed.

--- a/Web/Scotty/Action.hs
+++ b/Web/Scotty/Action.hs
@@ -65,7 +65,6 @@ import Data.Bool (bool)
 import qualified Data.ByteString.Char8      as B
 import qualified Data.ByteString.Lazy.Char8 as BL
 import qualified Data.CaseInsensitive       as CI
-import           Data.Default.Class         (def)
 import           Data.Int
 import           Data.String (IsString(..))
 import qualified Data.Text                  as ST
@@ -177,7 +176,7 @@ raiseStatus s = E.throw . StatusError s
 -- >   text "You made a request to /foo/special"
 -- >
 -- > get "/foo/:baz" $ do
--- >   w <- param "baz"
+-- >   w <- captureParam "baz"
 -- >   text $ "You made a request to: " <> w
 next :: (Monad m) => ActionT m a
 next = E.throw Next
@@ -296,7 +295,6 @@ param k = do
 -- * Raises an exception which can be caught by 'rescue' if parameter is not found. If the exception is not caught, scotty will return a HTTP error code 500 ("Internal Server Error") to the client.
 --
 -- * If the parameter is found, but 'parseParam' fails to parse to the correct type, 'next' is called.
--- captureParam :: (Parsable a, ScottyError e, Monad m) => T.Text -> ActionT e m a
 captureParam :: (Parsable a, Monad m) => T.Text -> ActionT m a
 captureParam = paramWith CaptureParam envCaptureParams status500
 
@@ -305,7 +303,6 @@ captureParam = paramWith CaptureParam envCaptureParams status500
 -- * Raises an exception which can be caught by 'rescue' if parameter is not found. If the exception is not caught, scotty will return a HTTP error code 400 ("Bad Request") to the client.
 --
 -- * This function raises a code 400 also if the parameter is found, but 'parseParam' fails to parse to the correct type.
--- formParam :: (Parsable a, ScottyError e, Monad m) => T.Text -> ActionT e m a
 formParam :: (Parsable a, Monad m) => T.Text -> ActionT m a
 formParam = paramWith FormParam envFormParams status400
 
@@ -314,7 +311,6 @@ formParam = paramWith FormParam envFormParams status400
 -- * Raises an exception which can be caught by 'rescue' if parameter is not found. If the exception is not caught, scotty will return a HTTP error code 400 ("Bad Request") to the client.
 --
 -- * This function raises a code 400 also if the parameter is found, but 'parseParam' fails to parse to the correct type.
--- queryParam :: (Parsable a, ScottyError e, Monad m) => T.Text -> ActionT e m a
 queryParam :: (Parsable a, Monad m) => T.Text -> ActionT m a
 queryParam = paramWith QueryParam envQueryParams status400
 
@@ -428,7 +424,7 @@ readEither t = case [ x | (x,"") <- reads (T.unpack t) ] of
                 []  -> Left "readEither: no parse"
                 _   -> Left "readEither: ambiguous parse"
 
--- | Set the HTTP response status. Default is 200.
+-- | Set the HTTP response status.
 status :: MonadIO m => Status -> ActionT m ()
 status = modifyResponse . setStatus
 

--- a/Web/Scotty/Action.hs
+++ b/Web/Scotty/Action.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PackageImports #-}
 {-# LANGUAGE CPP               #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes        #-}
@@ -58,11 +61,13 @@ import           Control.Monad.Trans.Except
 import           Control.Concurrent.MVar
 
 import qualified Data.Aeson                 as A
+import Data.Bool (bool)
 import qualified Data.ByteString.Char8      as B
 import qualified Data.ByteString.Lazy.Char8 as BL
 import qualified Data.CaseInsensitive       as CI
 import           Data.Default.Class         (def)
 import           Data.Int
+import           Data.String (IsString(..))
 import qualified Data.Text                  as ST
 import qualified Data.Text.Encoding         as STE
 import qualified Data.Text.Lazy             as T
@@ -80,51 +85,74 @@ import           Network.Wai (Request, Response, StreamingBody, Application, req
 import           Numeric.Natural
 
 import           Prelude ()
-import           Prelude.Compat
+import "base-compat-batteries" Prelude.Compat
 
 import           Web.Scotty.Internal.Types
-import           Web.Scotty.Util (mkResponse, addIfNotPresent, add, replace, lazyTextToStrictByteString, strictByteStringToLazyText, catch, catchAny, tryAny)
+import           Web.Scotty.Util (mkResponse, addIfNotPresent, add, replace, lazyTextToStrictByteString, strictByteStringToLazyText, catch, catches, catchesOptionally, catchAny, try, tryAny)
 
 import Network.Wai.Internal (ResponseReceived(..))
 
--- Nothing indicates route failed (due to Next) and pattern matching should continue.
+-- | Nothing indicates route failed (due to Next) and pattern matching should continue.
 -- Just indicates a successful response.
 -- runAction :: (ScottyError e, Monad m) => ErrorHandler e m -> ActionEnv -> ActionT e m () -> m (Maybe Response)
--- runAction :: MonadUnliftIO m =>
---              Maybe a -> ActionEnv -> ActionT e m () -> m (Maybe Response)
 runAction :: MonadUnliftIO m =>
-             Maybe (AErr -> ActionT e m ())
-          -> ActionEnv -> ActionT e m () -> m (Maybe Response)
-runAction h env action = do
-  ei <- flip runReaderT env $ runAM $ tryAny (action `catch` defH h)
+             Maybe (ErrorHandler m) -- ^ if present, this handler is in charge of user-defined exceptions
+          -> ActionEnv -> ActionT m () -> m (Maybe Response)
+runAction mh env action = do
+  ok <- flip runReaderT env $ runAM $ tryNext (catchesOptionally action mh actionErrorHandler )
   res <- getResponse env
-  return $ either (const Nothing) (const $ Just $ mkResponse res) ei
+  return $ bool Nothing (Just $ mkResponse res) ok
+  -- return $ either (const Nothing) (const $ Just $ mkResponse res) ei
 
 
--- | Default error handler for all actions.
--- defH :: (Monad m) => ErrorHandler e m -> ActionError -> ActionT e m ()
--- defH :: MonadIO m => Maybe a -> ActionError -> ActionT e m ()
-defH :: MonadUnliftIO m => Maybe (AErr -> ActionT e m ()) -> ActionError -> ActionT e m ()
-defH _          (Redirect url)    = do
+{-|
+* ActionError should only be caught by runAction
+* handlers should not throw ActionError (= do not export ActionError constructors)
+-}
+
+tryNext :: MonadUnliftIO m => m a -> m Bool
+tryNext io = catch (io >> pure True) $ \e ->
+  case e of
+    Next -> pure False
+    _ -> pure True
+
+-- | Error handler in charge of 'ActionError'. Rethrowing 'Next' here is caught by 'tryNext'
+actionErrorHandler :: MonadIO m => ErrorHandler m -- ActionError -> ActionT m ()
+actionErrorHandler = Handler $ \case
+  Redirect url -> do
     status status302
     setHeader "Location" url
-defH Nothing    (ActionError s e)   = do
+  StatusError s e -> do
     status s
     let code = T.pack $ show $ statusCode s
     let msg = T.fromStrict $ STE.decodeUtf8 $ statusMessage s
-    html $ mconcat ["<h1>", code, " ", msg, "</h1>", T.pack (show e)]
-defH h@(Just f) (ActionError _ e)   = f e `catch` (defH h) -- so handlers can throw exceptions themselves -- TODO
-defH _          Next              = next
-defH _          Finish            = return ()
+    html $ mconcat ["<h1>", code, " ", msg, "</h1>", e]
+  Next -> next
+  Finish -> return ()
+
+-- -- defH :: (Monad m) => ErrorHandler e m -> ActionError -> ActionT e m ()
+-- defH :: MonadUnliftIO m => Maybe (AErr -> ActionT m ()) -> ActionError -> ActionT m ()
+-- defH _          (Redirect url)    = do
+--     status status302
+--     setHeader "Location" url
+-- defH Nothing    (ActionError s e)   = do
+--     status s
+--     let code = T.pack $ show $ statusCode s
+--     let msg = T.fromStrict $ STE.decodeUtf8 $ statusMessage s
+--     html $ mconcat ["<h1>", code, " ", msg, "</h1>", T.pack (show e)]
+-- defH h@(Just f) (ActionError _ e)   = f e `catch` (defH h) -- so handlers can throw exceptions themselves -- TODO
+-- defH _          Next              = next      -- rethrow 'Next'
+-- defH _          Finish            = return () -- stop
 
 -- | Throw an exception, which can be caught with 'rescue'. Uncaught exceptions
 -- turn into HTTP 500 responses.
-raise :: (Monad m) => AErr -> ActionT e m a
-raise = raiseStatus status500
+-- raise :: (Monad m) => AErr -> ActionT m a
+raise :: (MonadIO m, E.Exception e) => e -> ActionT m a
+raise = E.throw -- raiseStatus status500
 
 -- | Throw an exception, which can be caught with 'rescue'. Uncaught exceptions turn into HTTP responses corresponding to the given status.
-raiseStatus :: (Monad m) => Status -> AErr -> ActionT e m a
-raiseStatus s = E.throw . ActionError s
+raiseStatus :: (Monad m) => Status -> T.Text -> ActionT m a
+raiseStatus s = E.throw . StatusError s
 
 
 -- | Abort execution of this action and continue pattern matching routes.
@@ -141,23 +169,21 @@ raiseStatus s = E.throw . ActionError s
 -- > get "/foo/:baz" $ do
 -- >   w <- param "baz"
 -- >   text $ "You made a request to: " <> w
-next :: (Monad m) => ActionT e m a
+next :: (Monad m) => ActionT m a
 next = E.throw Next
 
 -- | Catch an exception thrown by 'raise'.
 --
--- > raise "just kidding" `rescue` (\msg -> text msg)
-rescue :: (MonadUnliftIO m) => ActionT e m a -> (AErr -> ActionT e m a) -> ActionT e m a
-rescue action h = catch action $ \e -> case e of
-  ActionError _ err -> h err -- handle errors
-  other -> E.throw other -- rethrow internal error types
+-- > raise JustKidding `rescue` (\msg -> text msg)
+rescue :: (MonadUnliftIO m, E.Exception e) => ActionT m a -> (e -> ActionT m a) -> ActionT m a
+rescue = catch
 
--- | Like 'liftIO', but catch any IO exceptions and turn them into 'ScottyError's.
-liftAndCatchIO = undefined -- FIXME
--- liftAndCatchIO :: (ScottyError e, MonadIO m) => IO a -> ActionT e m a
--- liftAndCatchIO io = ActionT $ do
---     r <- liftIO $ liftM Right io `E.catch` (\ e -> return $ Left $ stringError $ show (e :: E.SomeException))
---     either throwError return r
+-- | Catch any synchronous IO exceptions
+liftAndCatchIO :: MonadIO m => IO a -> ActionT m a
+liftAndCatchIO io = liftIO $ do
+  r <- tryAny io
+  either E.throwIO pure r
+
 
 -- | Redirect to given URL. Like throwing an uncatchable exception. Any code after the call to redirect
 -- will not be run.
@@ -167,7 +193,7 @@ liftAndCatchIO = undefined -- FIXME
 -- OR
 --
 -- > redirect "/foo/bar"
-redirect :: (Monad m) => T.Text -> ActionT e m a
+redirect :: (Monad m) => T.Text -> ActionT m a
 redirect = E.throw . Redirect
 
 -- | Finish the execution of the current action. Like throwing an uncatchable
@@ -175,25 +201,25 @@ redirect = E.throw . Redirect
 --
 -- /Since: 0.10.3/
 -- finish :: (ScottyError e, Monad m) => ActionT e m a
-finish :: (Monad m) => ActionT e m a
+finish :: (Monad m) => ActionT m a
 finish = E.throw Finish
 
 -- | Get the 'Request' object.
-request :: Monad m => ActionT e m Request
+request :: Monad m => ActionT m Request
 request = ActionT $ envReq <$> ask
 
 -- | Get list of uploaded files.
-files :: Monad m => ActionT e m [File]
+files :: Monad m => ActionT m [File]
 files = ActionT $ envFiles <$> ask
 
 -- | Get a request header. Header name is case-insensitive.
-header :: (Monad m) => T.Text -> ActionT e m (Maybe T.Text)
+header :: (Monad m) => T.Text -> ActionT m (Maybe T.Text)
 header k = do
     hs <- requestHeaders <$> request
     return $ fmap strictByteStringToLazyText $ lookup (CI.mk (lazyTextToStrictByteString k)) hs
 
 -- | Get all the request headers. Header names are case-insensitive.
-headers :: (Monad m) => ActionT e m [(T.Text, T.Text)]
+headers :: (Monad m) => ActionT m [(T.Text, T.Text)]
 headers = do
     hs <- requestHeaders <$> request
     return [ ( strictByteStringToLazyText (CI.original k)
@@ -201,13 +227,13 @@ headers = do
            | (k,v) <- hs ]
 
 -- | Get the request body.
-body :: (ScottyError e,  MonadIO m) => ActionT e m BL.ByteString
+body :: (MonadIO m) => ActionT m BL.ByteString
 body = ActionT ask >>= (liftIO . envBody)
 
 -- | Get an IO action that reads body chunks
 --
 -- * This is incompatible with 'body' since 'body' consumes all chunks.
-bodyReader :: Monad m => ActionT e m (IO B.ByteString)
+bodyReader :: Monad m => ActionT m (IO B.ByteString)
 bodyReader = ActionT $ envBodyChunk <$> ask
 
 -- | Parse the request body as a JSON object and return it.
@@ -219,27 +245,26 @@ bodyReader = ActionT $ envBodyChunk <$> ask
 --   422 Unprocessable Entity.
 --
 --   These status codes are as per https://www.restapitutorial.com/httpstatuscodes.html.
-jsonData = undefined
--- jsonData :: (A.FromJSON a, ScottyError e, MonadIO m) => ActionT e m a
--- jsonData = do
---     b <- body
---     when (b == "") $ do
---       let htmlError = "jsonData - No data was provided."
---       raiseStatus status400 $ stringError htmlError
---     case A.eitherDecode b of
---       Left err -> do
---         let htmlError = "jsonData - malformed."
---               `mappend` " Data was: " `mappend` BL.unpack b
---               `mappend` " Error was: " `mappend` err
---         raiseStatus status400 $ stringError htmlError
---       Right value -> case A.fromJSON value of
---         A.Error err -> do
---           let htmlError = "jsonData - failed parse."
---                 `mappend` " Data was: " `mappend` BL.unpack b `mappend` "."
---                 `mappend` " Error was: " `mappend` err
---           raiseStatus status422 $ stringError htmlError
---         A.Success a -> do
---           return a
+jsonData :: (A.FromJSON a, MonadIO m) => ActionT m a
+jsonData = do
+    b <- body
+    when (b == "") $ do
+      let htmlError = "jsonData - No data was provided."
+      raiseStatus status400 $ T.pack htmlError
+    case A.eitherDecode b of
+      Left err -> do
+        let htmlError = "jsonData - malformed."
+              `mappend` " Data was: " `mappend` BL.unpack b
+              `mappend` " Error was: " `mappend` err
+        raiseStatus status400 $ T.pack htmlError
+      Right value -> case A.fromJSON value of
+        A.Error err -> do
+          let htmlError = "jsonData - failed parse."
+                `mappend` " Data was: " `mappend` BL.unpack b `mappend` "."
+                `mappend` " Error was: " `mappend` err
+          raiseStatus status422 $ T.pack htmlError
+        A.Success a -> do
+          return a
 
 -- | Get a parameter. First looks in captures, then form data, then query parameters.
 --
@@ -248,11 +273,11 @@ jsonData = undefined
 -- * If parameter is found, but 'parseParam' fails to parse to the correct type, 'next' is called.
 --   This means captures are somewhat typed, in that a route won't match if a correctly typed
 --   capture cannot be parsed.
--- param :: (Parsable a, ScottyError e, Monad m) => T.Text -> ActionT e m a
+param :: (Parsable a, MonadIO m) => T.Text -> ActionT m a
 param k = do
     val <- ActionT $ (lookup k . getParams) <$> ask
     case val of
-        -- Nothing -> raise $ stringError $ "Param: " ++ T.unpack k ++ " not found!" -- FIXME
+        Nothing -> raiseStatus status500 $ "Param: " <> k <> " not found!" -- FIXME
         Just v  -> either (const next) return $ parseParam v
 {-# DEPRECATED param "(#204) Not a good idea to treat all parameters identically. Use captureParam, formParam and queryParam instead. "#-}
 
@@ -262,7 +287,7 @@ param k = do
 --
 -- * If the parameter is found, but 'parseParam' fails to parse to the correct type, 'next' is called.
 -- captureParam :: (Parsable a, ScottyError e, Monad m) => T.Text -> ActionT e m a
-captureParam :: (Parsable a, Monad m) => T.Text -> ActionT e m a
+captureParam :: (Parsable a, Monad m) => T.Text -> ActionT m a
 captureParam = paramWith CaptureParam envCaptureParams status500
 
 -- | Get a form parameter.
@@ -271,7 +296,7 @@ captureParam = paramWith CaptureParam envCaptureParams status500
 --
 -- * This function raises a code 400 also if the parameter is found, but 'parseParam' fails to parse to the correct type.
 -- formParam :: (Parsable a, ScottyError e, Monad m) => T.Text -> ActionT e m a
-formParam :: (Parsable a, Monad m) => T.Text -> ActionT e m a
+formParam :: (Parsable a, Monad m) => T.Text -> ActionT m a
 formParam = paramWith FormParam envFormParams status400
 
 -- | Get a query parameter.
@@ -280,7 +305,7 @@ formParam = paramWith FormParam envFormParams status400
 --
 -- * This function raises a code 400 also if the parameter is found, but 'parseParam' fails to parse to the correct type.
 -- queryParam :: (Parsable a, ScottyError e, Monad m) => T.Text -> ActionT e m a
-queryParam :: (Parsable a, Monad m) => T.Text -> ActionT e m a
+queryParam :: (Parsable a, Monad m) => T.Text -> ActionT m a
 queryParam = paramWith QueryParam envQueryParams status400
 
 data ParamType = CaptureParam
@@ -297,33 +322,33 @@ paramWith :: (Monad m, Parsable b) =>
           -> (ActionEnv -> [Param])
           -> Status -- ^ HTTP status to return if parameter is not found
           -> T.Text -- ^ parameter name
-          -> ActionT e m b
+          -> ActionT m b
 paramWith ty f err k = do
     val <- ActionT $ (lookup k . f) <$> ask
     case val of
-      -- Nothing -> raiseStatus err $ stringError (unwords [show ty, "parameter:", T.unpack k, "not found!"]) -- FIXME
+      Nothing -> raiseStatus err (T.unwords [T.pack (show ty), "parameter:", k, "not found!"])
       Just v ->
         let handleParseError = \case
               CaptureParam -> next
-              -- _ -> raiseStatus err $ stringError (unwords ["Cannot parse", T.unpack v, "as a", show ty, "parameter"]) -- FIXME
+              _ -> raiseStatus err (T.unwords ["Cannot parse", v, "as a", T.pack (show ty), "parameter"])
         in either (const $ handleParseError ty) return $ parseParam v
 
 -- | Get all parameters from capture, form and query (in that order).
-params :: Monad m => ActionT e m [Param]
+params :: Monad m => ActionT m [Param]
 params = paramsWith getParams
 {-# DEPRECATED params "(#204) Not a good idea to treat all parameters identically. Use captureParams, formParams and queryParams instead. "#-}
 
 -- | Get capture parameters
-captureParams :: Monad m => ActionT e m [Param]
+captureParams :: Monad m => ActionT m [Param]
 captureParams = paramsWith envCaptureParams
 -- | Get form parameters
-formParams :: Monad m => ActionT e m [Param]
+formParams :: Monad m => ActionT m [Param]
 formParams = paramsWith envFormParams
 -- | Get query parameters
-queryParams :: Monad m => ActionT e m [Param]
+queryParams :: Monad m => ActionT m [Param]
 queryParams = paramsWith envQueryParams
 
-paramsWith :: Monad m => (ActionEnv -> a) -> ActionT e m a
+paramsWith :: Monad m => (ActionEnv -> a) -> ActionT m a
 paramsWith f = ActionT (f <$> ask)
 
 {-# DEPRECATED getParams "(#204) Not a good idea to treat all parameters identically" #-}
@@ -394,35 +419,35 @@ readEither t = case [ x | (x,"") <- reads (T.unpack t) ] of
                 _   -> Left "readEither: ambiguous parse"
 
 -- | Set the HTTP response status. Default is 200.
-status :: Monad m => Status -> ActionT e m ()
-status = undefined -- FIXME
+status :: MonadIO m => Status -> ActionT m ()
+status = modifyResponse . setStatus
 
 -- Not exported, but useful in the functions below.
 changeHeader :: MonadIO m
              => (CI.CI B.ByteString -> B.ByteString -> [(HeaderName, B.ByteString)] -> [(HeaderName, B.ByteString)])
-             -> T.Text -> T.Text -> ActionT e m ()
+             -> T.Text -> T.Text -> ActionT m ()
 changeHeader f k =
   modifyResponse . setHeaderWith . f (CI.mk $ lazyTextToStrictByteString k) . lazyTextToStrictByteString
 
 -- | Add to the response headers. Header names are case-insensitive.
-addHeader :: MonadIO m => T.Text -> T.Text -> ActionT e m ()
+addHeader :: MonadIO m => T.Text -> T.Text -> ActionT m ()
 addHeader = changeHeader add
 
 -- | Set one of the response headers. Will override any previously set value for that header.
 -- Header names are case-insensitive.
-setHeader :: MonadIO m => T.Text -> T.Text -> ActionT e m ()
+setHeader :: MonadIO m => T.Text -> T.Text -> ActionT m ()
 setHeader = changeHeader replace
 
 -- | Set the body of the response to the given 'T.Text' value. Also sets \"Content-Type\"
 -- header to \"text/plain; charset=utf-8\" if it has not already been set.
-text :: (MonadIO m) => T.Text -> ActionT e m ()
+text :: (MonadIO m) => T.Text -> ActionT m ()
 text t = do
     changeHeader addIfNotPresent "Content-Type" "text/plain; charset=utf-8"
     raw $ encodeUtf8 t
 
 -- | Set the body of the response to the given 'T.Text' value. Also sets \"Content-Type\"
 -- header to \"text/html; charset=utf-8\" if it has not already been set.
-html :: (MonadIO m) => T.Text -> ActionT e m ()
+html :: (MonadIO m) => T.Text -> ActionT m ()
 html t = do
     changeHeader addIfNotPresent "Content-Type" "text/html; charset=utf-8"
     raw $ encodeUtf8 t
@@ -430,15 +455,15 @@ html t = do
 -- | Send a file as the response. Doesn't set the \"Content-Type\" header, so you probably
 -- want to do that on your own with 'setHeader'. Setting a status code will have no effect
 -- because Warp will overwrite that to 200 (see 'Network.Wai.Handler.Warp.Internal.sendResponse').
-file :: Monad m => FilePath -> ActionT e m ()
-file = undefined -- FIXME
+file :: MonadIO m => FilePath -> ActionT m ()
+file = modifyResponse . setContent . ContentFile
 
-rawResponse :: Monad m => Response -> ActionT e m ()
-rawResponse = undefined -- FIXME
+rawResponse :: MonadIO m => Response -> ActionT m ()
+rawResponse = modifyResponse . setContent . ContentResponse
 
 -- | Set the body of the response to the JSON encoding of the given value. Also sets \"Content-Type\"
 -- header to \"application/json; charset=utf-8\" if it has not already been set.
-json :: (A.ToJSON a, MonadIO m) => a -> ActionT e m ()
+json :: (A.ToJSON a, MonadIO m) => a -> ActionT m ()
 json v = do
     changeHeader addIfNotPresent "Content-Type" "application/json; charset=utf-8"
     raw $ A.encode v
@@ -446,18 +471,18 @@ json v = do
 -- | Set the body of the response to a Source. Doesn't set the
 -- \"Content-Type\" header, so you probably want to do that on your
 -- own with 'setHeader'.
-stream :: MonadIO m => StreamingBody -> ActionT e m ()
+stream :: MonadIO m => StreamingBody -> ActionT m ()
 stream = modifyResponse . setContent . ContentStream
 
 -- | Set the body of the response to the given 'BL.ByteString' value. Doesn't set the
 -- \"Content-Type\" header, so you probably want to do that on your
 -- own with 'setHeader'.
-raw :: MonadIO m => BL.ByteString -> ActionT e m ()
+raw :: MonadIO m => BL.ByteString -> ActionT m ()
 raw = modifyResponse . setContent . ContentBuilder . fromLazyByteString
 
 -- | Nest a whole WAI application inside a Scotty handler.
 -- See Web.Scotty for further documentation
-nested :: (MonadIO m) => Network.Wai.Application -> ActionT e m ()
+nested :: (MonadIO m) => Network.Wai.Application -> ActionT m ()
 nested app = do
   -- Is MVar really the best choice here? Not sure.
   r <- request

--- a/Web/Scotty/Action.hs
+++ b/Web/Scotty/Action.hs
@@ -133,19 +133,25 @@ someExceptionHandler :: MonadIO m => ErrorHandler m
 someExceptionHandler = Handler $ \case
   (_ :: E.SomeException) -> status status500
 
-
 -- | Throw a "500 Server Error" 'StatusError', which can be caught with 'rescue'.
+--
 -- Uncaught exceptions turn into HTTP 500 responses.
 raise :: (MonadIO m) =>
          T.Text -- ^ Error text
       -> ActionT m a
 raise  = raiseStatus status500
 
--- | Throw a 'StatusError' exception that has an associated HTTP error code and can be caught with 'rescue'. Uncaught exceptions turn into HTTP responses corresponding to the given status.
+-- | Throw a 'StatusError' exception that has an associated HTTP error code and can be caught with 'rescue'.
+--
+-- Uncaught exceptions turn into HTTP responses corresponding to the given status.
 raiseStatus :: Monad m => Status -> T.Text -> ActionT m a
 raiseStatus s = E.throw . StatusError s
 
--- | Throw an exception. A user-defined 'Handler' will then have to define its interpretation and a translation to HTTP error codes.
+-- | Throw an exception which can be caught within the scope of the current Action with 'rescue' or 'catch'.
+--
+-- If the exception is not caught locally, another option is to implement a global 'Handler' (with 'defaultHandler') that defines its interpretation and a translation to HTTP error codes.
+--
+-- Uncaught exceptions turn into HTTP 500 responses.
 throw :: (MonadIO m, E.Exception e) => e -> ActionT m a
 throw = E.throw
 

--- a/Web/Scotty/Action.hs
+++ b/Web/Scotty/Action.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE RankNTypes        #-}
 {-# LANGUAGE LambdaCase #-}
 {-# language ScopedTypeVariables #-}
-{-# options_ghc -Wno-unused-imports #-}
 module Web.Scotty.Action
     ( addHeader
     , body
@@ -52,13 +51,10 @@ module Web.Scotty.Action
 import           Blaze.ByteString.Builder   (fromLazyByteString)
 
 import qualified Control.Exception          as E
-import           Control.Monad              (liftM, when)
-import           Control.Monad.Error.Class (throwError, catchError)
+import           Control.Monad              (when)
 import           Control.Monad.IO.Class     (MonadIO(..))
 import UnliftIO (MonadUnliftIO(..))
 import           Control.Monad.Reader       (MonadReader(..), ReaderT(..))
-import qualified Control.Monad.State.Strict as MS
-import           Control.Monad.Trans.Except
 
 import           Control.Concurrent.MVar
 
@@ -68,12 +64,10 @@ import qualified Data.ByteString.Char8      as B
 import qualified Data.ByteString.Lazy.Char8 as BL
 import qualified Data.CaseInsensitive       as CI
 import           Data.Int
-import           Data.String (IsString(..))
 import qualified Data.Text                  as ST
 import qualified Data.Text.Encoding         as STE
 import qualified Data.Text.Lazy             as T
 import           Data.Text.Lazy.Encoding    (encodeUtf8)
-import           Data.Typeable (Typeable)
 import           Data.Word
 
 import           Network.HTTP.Types
@@ -90,7 +84,7 @@ import "base-compat-batteries" Prelude.Compat
 
 import           Web.Scotty.Internal.Types
 import           Web.Scotty.Util (mkResponse, addIfNotPresent, add, replace, lazyTextToStrictByteString, strictByteStringToLazyText)
-import Web.Scotty.Exceptions (Handler(..), catch, catches, catchesOptionally, catchAny, try, tryAny)
+import Web.Scotty.Exceptions (Handler(..), catch, catchesOptionally, tryAny)
 
 import Network.Wai.Internal (ResponseReceived(..))
 

--- a/Web/Scotty/Action.hs
+++ b/Web/Scotty/Action.hs
@@ -188,7 +188,6 @@ redirect = E.throw . Redirect
 -- exception. Any code after the call to finish will not be run.
 --
 -- /Since: 0.10.3/
--- finish :: (ScottyError e, Monad m) => ActionT e m a
 finish :: (Monad m) => ActionT m a
 finish = E.throw Finish
 

--- a/Web/Scotty/Body.hs
+++ b/Web/Scotty/Body.hs
@@ -15,10 +15,10 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B
 import qualified Data.ByteString.Lazy.Char8 as BL
 import           Data.Maybe
-import           GHC.Exception
+import qualified GHC.Exception as E (throw)
 import           Network.Wai (Request(..), getRequestBodyChunk)
 import qualified Network.Wai.Parse as W (File, Param, getRequestBodyType, BackEnd, lbsBackEnd, sinkRequestBody)
-import           Web.Scotty.Action
+import           Web.Scotty.Action (Param)
 import           Web.Scotty.Internal.Types (BodyInfo(..), BodyChunkBuffer(..), BodyPartiallyStreamed(..), RouteOptions(..))
 import           Web.Scotty.Util (readRequestBody, strictByteStringToLazyText)
 
@@ -60,7 +60,7 @@ getBodyAction :: BodyInfo -> RouteOptions -> IO (BL.ByteString)
 getBodyAction (BodyInfo readProgress chunkBufferVar getChunk) opts =
   modifyMVar readProgress $ \index ->
     modifyMVar chunkBufferVar $ \bcb@(BodyChunkBuffer hasFinished chunks) -> do
-      if | index > 0 -> throw BodyPartiallyStreamed
+      if | index > 0 -> E.throw BodyPartiallyStreamed
          | hasFinished -> return (bcb, (index, BL.fromChunks chunks))
          | otherwise -> do
              newChunks <- readRequestBody getChunk return (maxRequestBodySize opts)

--- a/Web/Scotty/Body.hs
+++ b/Web/Scotty/Body.hs
@@ -20,7 +20,7 @@ import           Network.Wai (Request(..), getRequestBodyChunk)
 import qualified Network.Wai.Parse as W (File, Param, getRequestBodyType, BackEnd, lbsBackEnd, sinkRequestBody)
 import           Web.Scotty.Action
 import           Web.Scotty.Internal.Types (BodyInfo(..), BodyChunkBuffer(..), BodyPartiallyStreamed(..), RouteOptions(..))
-import           Web.Scotty.Util
+import           Web.Scotty.Util (readRequestBody, strictByteStringToLazyText)
 
 -- | Make a new BodyInfo with readProgress at 0 and an empty BodyChunkBuffer.
 newBodyInfo :: (MonadIO m) => Request -> m BodyInfo

--- a/Web/Scotty/Cookie.hs
+++ b/Web/Scotty/Cookie.hs
@@ -92,7 +92,7 @@ import qualified Data.Text.Lazy.Encoding as TL (encodeUtf8, decodeUtf8)
 -- | Set a cookie, with full access to its options (see 'SetCookie')
 setCookie :: (MonadIO m)
           => SetCookie
-          -> ActionT e m ()
+          -> ActionT m ()
 setCookie c = addHeader "Set-Cookie" (TL.decodeUtf8 . toLazyByteString $ renderSetCookie c)
 
 
@@ -100,26 +100,26 @@ setCookie c = addHeader "Set-Cookie" (TL.decodeUtf8 . toLazyByteString $ renderS
 setSimpleCookie :: (MonadIO m)
                 => Text -- ^ name
                 -> Text -- ^ value
-                -> ActionT e m ()
+                -> ActionT m ()
 setSimpleCookie n v = setCookie $ makeSimpleCookie n v
 
 -- | Lookup one cookie name
 getCookie :: (Monad m)
           => Text -- ^ name
-          -> ActionT e m (Maybe Text)
+          -> ActionT m (Maybe Text)
 getCookie c = lookup c <$> getCookies
 
 
 -- | Returns all cookies
 getCookies :: (Monad m)
-           => ActionT e m CookiesText
+           => ActionT m CookiesText
 getCookies = (maybe [] parse) <$> header "Cookie"
     where parse = parseCookiesText . BSL.toStrict . TL.encodeUtf8
 
 -- | Browsers don't directly delete a cookie, but setting its expiry to a past date (e.g. the UNIX epoch) ensures that the cookie will be invalidated (whether and when it will be actually deleted by the browser seems to be browser-dependent).
 deleteCookie :: (MonadIO m)
              => Text -- ^ name
-             -> ActionT e m ()
+             -> ActionT m ()
 deleteCookie c = setCookie $ (makeSimpleCookie c "") { setCookieExpires = Just $ posixSecondsToUTCTime 0 }
 
 

--- a/Web/Scotty/Exceptions.hs
+++ b/Web/Scotty/Exceptions.hs
@@ -15,10 +15,11 @@ import Data.Maybe (maybeToList)
 
 import UnliftIO (MonadUnliftIO(..), catch, catchAny, catches, try, tryAny, Handler(..))
 
+
+-- | Handlers are tried sequentially
 catchesOptionally :: MonadUnliftIO m =>
                      m a
                   -> Maybe (Handler m a) -- ^ if present, this 'Handler' is tried first
                   -> [Handler m a] -- ^ these are tried in order
                   -> m a
 catchesOptionally io mh handlers = io `catches` (maybeToList mh <> handlers)
-

--- a/Web/Scotty/Exceptions.hs
+++ b/Web/Scotty/Exceptions.hs
@@ -11,9 +11,6 @@ module Web.Scotty.Exceptions (
   , tryAny
                              ) where
 
-import Control.Exception (Exception (..), SomeException (..), SomeAsyncException (..))
-import qualified Control.Exception as EUnsafe (fromException, throwIO, catch)
-import           Control.Monad.IO.Class (MonadIO(..))
 import Data.Maybe (maybeToList)
 
 import UnliftIO (MonadUnliftIO(..), catch, catchAny, catches, try, tryAny, Handler(..))

--- a/Web/Scotty/Exceptions.hs
+++ b/Web/Scotty/Exceptions.hs
@@ -1,0 +1,75 @@
+{-# LANGUAGE ExistentialQuantification #-}
+module Web.Scotty.Exceptions (
+  Handler(..)
+  -- * catching
+  , catch
+  , catchAny
+  , catches
+  , catchesOptionally
+  -- * trying
+  , try
+  , tryAny
+                             ) where
+
+import Control.Exception (Exception (..), SomeException (..), SomeAsyncException (..))
+import qualified Control.Exception as EUnsafe (fromException, throwIO, catch)
+import           Control.Monad.IO.Class (MonadIO(..))
+import Data.Maybe (maybeToList)
+
+import Control.Monad.IO.Unlift (MonadUnliftIO(..))
+
+-- | Handler for a specific type of exception, see 'handleActionError'
+data Handler m a = forall e . Exception e => Handler (e -> m a)
+instance Monad m => Functor (Handler m) where
+  fmap f (Handler h) = Handler (\e -> f <$> h e)
+
+
+-- exceptions
+
+catchesOptionally :: MonadUnliftIO m =>
+                     m a
+                  -> Maybe (Handler m a) -- ^ if present, this 'Handler' is tried first
+                  -> [Handler m a] -- ^ these are tried in order
+                  -> m a
+catchesOptionally io mh handlers = io `catches` (maybeToList mh <> handlers)
+
+catches :: MonadUnliftIO m => m a -> [Handler m a] -> m a
+catches io handlers = io `catch` catchesHandler handlers
+
+catchesHandler :: MonadIO m => [Handler m a] -> SomeException -> m a
+catchesHandler handlers e = foldr tryHandler (liftIO (EUnsafe.throwIO e)) handlers
+    where tryHandler (Handler h) res
+              = case EUnsafe.fromException e of
+                Just e' -> h e'
+                Nothing -> res
+
+-- | (from 'unliftio') Catch a synchronous (but not asynchronous) exception and recover from it.
+catch
+  :: (MonadUnliftIO m, Exception e)
+  => m a -- ^ action
+  -> (e -> m a) -- ^ handler
+  -> m a
+catch f g = withRunInIO $ \run -> run f `EUnsafe.catch` \e ->
+  if isSyncException e
+    then run (g e)
+    -- intentionally rethrowing an async exception synchronously,
+    -- since we want to preserve async behavior
+    else EUnsafe.throwIO e
+
+-- | 'catch' specialized to catch all synchronous exceptions.
+catchAny :: MonadUnliftIO m => m a -> (SomeException -> m a) -> m a
+catchAny = catch
+
+-- | (from 'safe-exceptions') Check if the given exception is synchronous
+isSyncException :: Exception e => e -> Bool
+isSyncException e =
+    case EUnsafe.fromException (toException e) of
+        Just (SomeAsyncException _) -> False
+        Nothing -> True
+
+try :: (MonadUnliftIO m, Exception e) => m a -> m (Either e a)
+try f = catch (Right <$> f) (pure . Left)
+
+-- | 'try' specialized to catch all synchronous exceptions.
+tryAny :: MonadUnliftIO m => m a -> m (Either SomeException a)
+tryAny = try

--- a/Web/Scotty/Exceptions.hs
+++ b/Web/Scotty/Exceptions.hs
@@ -16,15 +16,7 @@ import qualified Control.Exception as EUnsafe (fromException, throwIO, catch)
 import           Control.Monad.IO.Class (MonadIO(..))
 import Data.Maybe (maybeToList)
 
-import Control.Monad.IO.Unlift (MonadUnliftIO(..))
-
--- | Handler for a specific type of exception, see 'handleActionError'
-data Handler m a = forall e . Exception e => Handler (e -> m a)
-instance Monad m => Functor (Handler m) where
-  fmap f (Handler h) = Handler (\e -> f <$> h e)
-
-
--- exceptions
+import UnliftIO (MonadUnliftIO(..), catch, catchAny, catches, try, tryAny, Handler(..))
 
 catchesOptionally :: MonadUnliftIO m =>
                      m a
@@ -33,43 +25,3 @@ catchesOptionally :: MonadUnliftIO m =>
                   -> m a
 catchesOptionally io mh handlers = io `catches` (maybeToList mh <> handlers)
 
-catches :: MonadUnliftIO m => m a -> [Handler m a] -> m a
-catches io handlers = io `catch` catchesHandler handlers
-
-catchesHandler :: MonadIO m => [Handler m a] -> SomeException -> m a
-catchesHandler handlers e = foldr tryHandler (liftIO (EUnsafe.throwIO e)) handlers
-    where tryHandler (Handler h) res
-              = case EUnsafe.fromException e of
-                Just e' -> h e'
-                Nothing -> res
-
--- | (from 'unliftio') Catch a synchronous (but not asynchronous) exception and recover from it.
-catch
-  :: (MonadUnliftIO m, Exception e)
-  => m a -- ^ action
-  -> (e -> m a) -- ^ handler
-  -> m a
-catch f g = withRunInIO $ \run -> run f `EUnsafe.catch` \e ->
-  if isSyncException e
-    then run (g e)
-    -- intentionally rethrowing an async exception synchronously,
-    -- since we want to preserve async behavior
-    else EUnsafe.throwIO e
-
--- | 'catch' specialized to catch all synchronous exceptions.
-catchAny :: MonadUnliftIO m => m a -> (SomeException -> m a) -> m a
-catchAny = catch
-
--- | (from 'safe-exceptions') Check if the given exception is synchronous
-isSyncException :: Exception e => e -> Bool
-isSyncException e =
-    case EUnsafe.fromException (toException e) of
-        Just (SomeAsyncException _) -> False
-        Nothing -> True
-
-try :: (MonadUnliftIO m, Exception e) => m a -> m (Either e a)
-try f = catch (Right <$> f) (pure . Left)
-
--- | 'try' specialized to catch all synchronous exceptions.
-tryAny :: MonadUnliftIO m => m a -> m (Either SomeException a)
-tryAny = try

--- a/Web/Scotty/Internal/Types.hs
+++ b/Web/Scotty/Internal/Types.hs
@@ -27,7 +27,7 @@ import           Control.Monad.Catch (MonadCatch, MonadThrow)
 import           Control.Monad.Error.Class
 import qualified Control.Monad.Fail as Fail
 import           Control.Monad.IO.Class (MonadIO(..))
-import Control.Monad.IO.Unlift (MonadUnliftIO(..))
+import UnliftIO (MonadUnliftIO(..))
 import           Control.Monad.Reader (MonadReader(..), ReaderT, mapReaderT, asks)
 import           Control.Monad.State.Strict (MonadState(..), State, StateT(..), mapStateT, execState)
 import           Control.Monad.Trans.Class (MonadTrans(..))

--- a/Web/Scotty/Internal/Types.hs
+++ b/Web/Scotty/Internal/Types.hs
@@ -10,29 +10,23 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# options_ghc -Wno-unused-imports #-}
 module Web.Scotty.Internal.Types where
 
 import           Blaze.ByteString.Builder (Builder)
 
 import           Control.Applicative
 import Control.Concurrent.MVar
-import Control.Concurrent.STM (STM, TVar, atomically, newTVarIO, readTVarIO, readTVar, writeTVar, modifyTVar')
+import Control.Concurrent.STM (TVar, atomically, readTVarIO, modifyTVar')
 import qualified Control.Exception as E
-import qualified Control.Monad as Monad
 import           Control.Monad (MonadPlus(..))
-import           Control.Monad.Base (MonadBase, liftBase, liftBaseDefault)
+import           Control.Monad.Base (MonadBase)
 import           Control.Monad.Catch (MonadCatch, MonadThrow)
-import           Control.Monad.Error.Class
-import qualified Control.Monad.Fail as Fail
 import           Control.Monad.IO.Class (MonadIO(..))
 import UnliftIO (MonadUnliftIO(..))
-import           Control.Monad.Reader (MonadReader(..), ReaderT, mapReaderT, asks)
-import           Control.Monad.State.Strict (MonadState(..), State, StateT(..), mapStateT, execState)
+import           Control.Monad.Reader (MonadReader(..), ReaderT, asks)
+import           Control.Monad.State.Strict (State, StateT(..))
 import           Control.Monad.Trans.Class (MonadTrans(..))
-import           Control.Monad.Trans.Control (MonadBaseControl, StM, liftBaseWith, restoreM, ComposeSt, defaultLiftBaseWith, defaultRestoreM, MonadTransControl, StT, liftWith, restoreT)
-import           Control.Monad.Trans.Except
-
+import           Control.Monad.Trans.Control (MonadBaseControl, MonadTransControl)
 
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy.Char8 as LBS8 (ByteString)

--- a/Web/Scotty/Internal/Types.hs
+++ b/Web/Scotty/Internal/Types.hs
@@ -37,7 +37,7 @@ import           Control.Monad.Trans.Except
 
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy.Char8 as LBS8 (ByteString)
--- import           Data.Default.Class (Default, def)
+import           Data.Default.Class (Default, def)
 import           Data.String (IsString(..))
 import           Data.Text.Lazy (Text, pack)
 import           Data.Typeable (Typeable)
@@ -65,11 +65,17 @@ data Options = Options { verbose :: Int -- ^ 0 = silent, 1(def) = startup banner
                                               -- servers using `setFdCacheDuration`.
                        }
 
+instance Default Options where
+  def = defaultOptions
+
 defaultOptions :: Options
 defaultOptions = Options 1 defaultSettings
 
 newtype RouteOptions = RouteOptions { maxRequestBodySize :: Maybe Kilobytes -- max allowed request size in KB
                                     }
+
+instance Default RouteOptions where
+    def = defaultRouteOptions
 
 defaultRouteOptions :: RouteOptions
 defaultRouteOptions = RouteOptions Nothing
@@ -100,6 +106,9 @@ data ScottyState m =
                 , handler :: Maybe (ErrorHandler m)
                 , routeOptions :: RouteOptions
                 }
+
+instance Default (ScottyState m) where
+  def = defaultScottyState
 
 defaultScottyState :: ScottyState m
 defaultScottyState = ScottyState [] [] Nothing defaultRouteOptions
@@ -196,6 +205,9 @@ setHeaderWith f sr = sr { srHeaders = f (srHeaders sr) }
 
 setStatus :: Status -> ScottyResponse -> ScottyResponse
 setStatus s sr = sr { srStatus = s }
+
+instance Default ScottyResponse where
+  def = defaultScottyResponse
 
 -- | The default response has code 200 OK and empty body
 defaultScottyResponse :: ScottyResponse

--- a/Web/Scotty/Route.hs
+++ b/Web/Scotty/Route.hs
@@ -7,7 +7,7 @@ module Web.Scotty.Route
     ) where
 
 import           Control.Arrow ((***))
-import Control.Concurrent.STM (STM, TVar, atomically, newTVarIO)
+import Control.Concurrent.STM (newTVarIO)
 import           Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.IO.Unlift (MonadUnliftIO(..))
 import qualified Control.Monad.State as MS

--- a/Web/Scotty/Route.hs
+++ b/Web/Scotty/Route.hs
@@ -9,7 +9,7 @@ module Web.Scotty.Route
 import           Control.Arrow ((***))
 import Control.Concurrent.STM (newTVarIO)
 import           Control.Monad.IO.Class (MonadIO(..))
-import Control.Monad.IO.Unlift (MonadUnliftIO(..))
+import UnliftIO (MonadUnliftIO(..))
 import qualified Control.Monad.State as MS
 
 import qualified Data.ByteString.Char8 as B

--- a/Web/Scotty/Route.hs
+++ b/Web/Scotty/Route.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleContexts, FlexibleInstances,
              OverloadedStrings, RankNTypes, ScopedTypeVariables #-}
+{-# language PackageImports #-}
 module Web.Scotty.Route
     ( get, post, put, delete, patch, options, addroute, matchAny, notFound,
       capture, regex, function, literal
@@ -22,46 +23,46 @@ import           Network.HTTP.Types
 import           Network.Wai (Request(..))
 
 import           Prelude ()
-import           Prelude.Compat
+import "base-compat-batteries" Prelude.Compat
 
 import qualified Text.Regex as Regex
 
 import           Web.Scotty.Action
-import           Web.Scotty.Internal.Types (RoutePattern(..), RouteOptions, ActionEnv(..), ActionT, ScottyState(..), ScottyT(..), Middleware, BodyInfo, ScottyError(..), ErrorHandler, AErr, handler, addRoute, defaultScottyResponse)
+import           Web.Scotty.Internal.Types (RoutePattern(..), RouteOptions, ActionEnv(..), ActionT, ScottyState(..), ScottyT(..), ErrorHandler, Middleware, BodyInfo, handler, addRoute, defaultScottyResponse)
 import           Web.Scotty.Util (strictByteStringToLazyText)
 import Web.Scotty.Body (cloneBodyInfo, getBodyAction, getBodyChunkAction, getFormParamsAndFilesAction)
 
 -- | get = 'addroute' 'GET'
-get :: (MonadUnliftIO m) => RoutePattern -> ActionT e m () -> ScottyT e m ()
+get :: (MonadUnliftIO m) => RoutePattern -> ActionT m () -> ScottyT m ()
 get = addroute GET
 
 -- | post = 'addroute' 'POST'
-post :: (MonadUnliftIO m) => RoutePattern -> ActionT e m () -> ScottyT e m ()
+post :: (MonadUnliftIO m) => RoutePattern -> ActionT m () -> ScottyT m ()
 post = addroute POST
 
 -- | put = 'addroute' 'PUT'
-put :: (MonadUnliftIO m) => RoutePattern -> ActionT e m () -> ScottyT e m ()
+put :: (MonadUnliftIO m) => RoutePattern -> ActionT m () -> ScottyT m ()
 put = addroute PUT
 
 -- | delete = 'addroute' 'DELETE'
-delete :: (MonadUnliftIO m) => RoutePattern -> ActionT e m () -> ScottyT e m ()
+delete :: (MonadUnliftIO m) => RoutePattern -> ActionT m () -> ScottyT m ()
 delete = addroute DELETE
 
 -- | patch = 'addroute' 'PATCH'
-patch :: (MonadUnliftIO m) => RoutePattern -> ActionT e m () -> ScottyT e m ()
+patch :: (MonadUnliftIO m) => RoutePattern -> ActionT m () -> ScottyT m ()
 patch = addroute PATCH
 
 -- | options = 'addroute' 'OPTIONS'
-options :: (MonadUnliftIO m) => RoutePattern -> ActionT e m () -> ScottyT e m ()
+options :: (MonadUnliftIO m) => RoutePattern -> ActionT m () -> ScottyT m ()
 options = addroute OPTIONS
 
 -- | Add a route that matches regardless of the HTTP verb.
-matchAny :: (MonadUnliftIO m) => RoutePattern -> ActionT e m () -> ScottyT e m ()
-matchAny pattern action = ScottyT $ MS.modify $ \s -> addRoute (route (routeOptions s) (handler s) Nothing pattern action) s
+matchAny :: (MonadUnliftIO m) => RoutePattern -> ActionT m () -> ScottyT m ()
+matchAny pat action = ScottyT $ MS.modify $ \s -> addRoute (route (routeOptions s) (handler s) Nothing pat action) s
 
 -- | Specify an action to take if nothing else is found. Note: this _always_ matches,
 -- so should generally be the last route specified.
-notFound :: (MonadUnliftIO m) => ActionT e m () -> ScottyT e m ()
+notFound :: (MonadUnliftIO m) => ActionT m () -> ScottyT m ()
 notFound action = matchAny (Function (\req -> Just [("path", path req)])) (status status404 >> action)
 
 -- | Define a route with a 'StdMethod', 'T.Text' value representing the path spec,
@@ -70,25 +71,28 @@ notFound action = matchAny (Function (\req -> Just [("path", path req)])) (statu
 -- > addroute GET "/" $ text "beam me up!"
 --
 -- The path spec can include values starting with a colon, which are interpreted
--- as /captures/. These are named wildcards that can be looked up with 'param'.
+-- as /captures/. These are named wildcards that can be looked up with 'captureParam'.
 --
 -- > addroute GET "/foo/:bar" $ do
--- >     v <- param "bar"
+-- >     v <- captureParam "bar"
 -- >     text v
 --
 -- >>> curl http://localhost:3000/foo/something
 -- something
-addroute :: (MonadUnliftIO m) => StdMethod -> RoutePattern -> ActionT e m () -> ScottyT e m ()
+--
+-- NB: the 'RouteOptions' and the exception handler of the newly-created route will be
+-- copied from the previously-created routes.
+addroute :: (MonadUnliftIO m) => StdMethod -> RoutePattern -> ActionT m () -> ScottyT m ()
 addroute method pat action = ScottyT $ MS.modify $ \s -> addRoute (route (routeOptions s) (handler s) (Just method) pat action) s
 
 route :: (MonadUnliftIO m) =>
          RouteOptions
-      -> Maybe (AErr -> ActionT e m()) -> Maybe StdMethod -> RoutePattern -> ActionT e m () -> BodyInfo -> Middleware m
+      -> Maybe (ErrorHandler m) -> Maybe StdMethod -> RoutePattern -> ActionT m () -> BodyInfo -> Middleware m
 route opts h method pat action bodyInfo app req =
   let tryNext = app req
         {- |
           We match all methods in the case where 'method' is 'Nothing'.
-          See https://github.com/scotty-web/scotty/issues/196
+          See https://github.com/scotty-web/scotty/issues/196 and 'matchAny'
         -}
       methodMatches :: Bool
       methodMatches = maybe True (\x -> (Right x == parseMethod (requestMethod req))) method

--- a/Web/Scotty/Trans.hs
+++ b/Web/Scotty/Trans.hs
@@ -36,6 +36,7 @@ module Web.Scotty.Trans
     , text, html, file, json, stream, raw, nested
       -- ** Exceptions
     , raise, raiseStatus, throw, rescue, next, finish, defaultHandler, liftAndCatchIO
+    , StatusError(..)
       -- * Parsing Parameters
     , Param, Parsable(..), readEither
       -- * Types
@@ -59,7 +60,7 @@ import Network.Wai.Handler.Warp (Port, runSettings, runSettingsSocket, setPort, 
 
 import Web.Scotty.Action
 import Web.Scotty.Route
-import Web.Scotty.Internal.Types (ActionT(..), ScottyT(..), defaultScottyState, Application, RoutePattern, Options(..), defaultOptions, RouteOptions(..), defaultRouteOptions, ErrorHandler, Kilobytes, File, addMiddleware, setHandler, updateMaxRequestBodySize, routes, middlewares, ScottyException(..), ScottyState, defaultScottyState)
+import Web.Scotty.Internal.Types (ActionT(..), ScottyT(..), defaultScottyState, Application, RoutePattern, Options(..), defaultOptions, RouteOptions(..), defaultRouteOptions, ErrorHandler, Kilobytes, File, addMiddleware, setHandler, updateMaxRequestBodySize, routes, middlewares, ScottyException(..), ScottyState, defaultScottyState, StatusError(..))
 import Web.Scotty.Util (socketDescription)
 import Web.Scotty.Body (newBodyInfo)
 import Web.Scotty.Exceptions (Handler(..), catches)

--- a/Web/Scotty/Trans.hs
+++ b/Web/Scotty/Trans.hs
@@ -38,7 +38,7 @@ module Web.Scotty.Trans
       -- * Parsing Parameters
     , Param, Parsable(..), readEither
       -- * Types
-    , RoutePattern, File, Kilobytes
+    , RoutePattern, File, Kilobytes, ErrorHandler, Handler(..)
       -- * Monad Transformers
     , ScottyT, ActionT
     ) where
@@ -63,6 +63,7 @@ import Web.Scotty.Internal.Types hiding (Application, Middleware)
 import Web.Scotty.Util (socketDescription)
 import qualified Web.Scotty.Internal.Types as Scotty
 import Web.Scotty.Body (newBodyInfo)
+import Web.Scotty.Exceptions (Handler(..))
 
 -- | Run a scotty application using the warp server.
 -- NB: scotty p === scottyT p id

--- a/Web/Scotty/Trans.hs
+++ b/Web/Scotty/Trans.hs
@@ -42,6 +42,7 @@ module Web.Scotty.Trans
     , RoutePattern, File, Kilobytes, ErrorHandler, Handler(..)
       -- * Monad Transformers
     , ScottyT, ActionT
+    , ScottyState, defaultScottyState
     ) where
 
 import Blaze.ByteString.Builder (fromByteString)
@@ -58,7 +59,7 @@ import Network.Wai.Handler.Warp (Port, runSettings, runSettingsSocket, setPort, 
 
 import Web.Scotty.Action
 import Web.Scotty.Route
-import Web.Scotty.Internal.Types (ActionT(..), ScottyT(..), defaultScottyState, Application, RoutePattern, Options(..), defaultOptions, RouteOptions(..), defaultRouteOptions, ErrorHandler, Kilobytes, File, addMiddleware, setHandler, updateMaxRequestBodySize, routes, middlewares, ScottyException(..))
+import Web.Scotty.Internal.Types (ActionT(..), ScottyT(..), defaultScottyState, Application, RoutePattern, Options(..), defaultOptions, RouteOptions(..), defaultRouteOptions, ErrorHandler, Kilobytes, File, addMiddleware, setHandler, updateMaxRequestBodySize, routes, middlewares, ScottyException(..), ScottyState, defaultScottyState)
 import Web.Scotty.Util (socketDescription)
 import Web.Scotty.Body (newBodyInfo)
 import Web.Scotty.Exceptions (Handler(..), catches)
@@ -129,7 +130,7 @@ defaultHandler f = ScottyT $ modify $ setHandler $ Just f
 scottyExceptionHandler :: MonadIO m => Handler m W.Response
 scottyExceptionHandler = Handler $ \case
   RequestException ebody s -> do
-    return $ W.responseBuilder s [] (fromByteString ebody)
+    return $ W.responseBuilder s [("Content-Type", "text/plain")] (fromByteString ebody)
 
 
 -- | Use given middleware. Middleware is nested such that the first declared

--- a/Web/Scotty/Trans.hs
+++ b/Web/Scotty/Trans.hs
@@ -35,7 +35,7 @@ module Web.Scotty.Trans
       -- definition, as they completely replace the current 'Response' body.
     , text, html, file, json, stream, raw, nested
       -- ** Exceptions
-    , raise, raiseStatus, rescue, next, finish, defaultHandler, liftAndCatchIO
+    , raise, raiseStatus, throw, rescue, next, finish, defaultHandler, liftAndCatchIO
       -- * Parsing Parameters
     , Param, Parsable(..), readEither
       -- * Types

--- a/Web/Scotty/Util.hs
+++ b/Web/Scotty/Util.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE LambdaCase #-}
+{-# options_ghc -Wno-unused-imports #-}
 module Web.Scotty.Util
     ( lazyTextToStrictByteString
     , strictByteStringToLazyText

--- a/Web/Scotty/Util.hs
+++ b/Web/Scotty/Util.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE LambdaCase #-}
-{-# options_ghc -Wno-unused-imports #-}
 module Web.Scotty.Util
     ( lazyTextToStrictByteString
     , strictByteStringToLazyText
@@ -15,10 +14,7 @@ import Network.Socket (SockAddr(..), Socket, getSocketName, socketPort)
 import Network.Wai
 
 import Control.Monad (when)
-import           Control.Monad.IO.Class (MonadIO(..))
-import UnliftIO (MonadUnliftIO(..))
-import Control.Exception (Exception (..), SomeException (..), IOException, SomeAsyncException (..))
-import qualified Control.Exception as EUnsafe (fromException, throw, throwIO, catch)
+import qualified Control.Exception as EUnsafe (throw)
 
 
 import Network.HTTP.Types

--- a/Web/Scotty/Util.hs
+++ b/Web/Scotty/Util.hs
@@ -16,7 +16,7 @@ import Network.Wai
 
 import Control.Monad (when)
 import           Control.Monad.IO.Class (MonadIO(..))
-import Control.Monad.IO.Unlift (MonadUnliftIO(..))
+import UnliftIO (MonadUnliftIO(..))
 import Control.Exception (Exception (..), SomeException (..), IOException, SomeAsyncException (..))
 import qualified Control.Exception as EUnsafe (fromException, throw, throwIO, catch)
 

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -6,9 +6,7 @@
 module Main (main) where
 
 import Control.Monad
-import Data.Default.Class (def)
 import Data.Functor.Identity
-import Data.Text (Text)
 import Lucid.Base
 import Lucid.Html5
 import Web.Scotty
@@ -25,9 +23,9 @@ main = do
     setColumns [Case,Allocated,GCs,Live,Check,Max,MaxOS]
     setFormat Markdown
     io "ScottyM Strict" BL.putStr
-      (SS.evalState (runS $ renderBST htmlScotty) def)
+      (SS.evalState (runS $ renderBST htmlScotty) defaultScottyState)
     io "ScottyM Lazy" BL.putStr
-      (SL.evalState (runScottyLazy $ renderBST htmlScottyLazy) def)
+      (SL.evalState (runScottyLazy $ renderBST htmlScottyLazy) defaultScottyState)
     io "Identity" BL.putStr
       (runIdentity $ renderBST htmlIdentity)
 
@@ -49,6 +47,6 @@ htmlScottyLazy = htmlTest
 {-# noinline htmlScottyLazy #-}
 
 newtype ScottyLazy a = ScottyLazy
-  { runScottyLazy:: SL.State (ScottyState Text IO) a }
+  { runScottyLazy:: SL.State (ScottyState IO) a }
   deriving (Functor,Applicative,Monad)
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,10 +1,16 @@
 ## next [????.??.??]
-* Adds a new `nested` handler that allows you to place an entire WAI Application under a Scotty route
-* Disambiguate request parameters (#204). Adjust the `Env` type to have three [Param] fields instead of one, add `captureParam`, `formParam`, `queryParam` and the associated `captureParams`, `formParams`, `queryParams`. Add deprecation notices to `param` and `params`.
-* Add `Scotty.Cookie` module.
-* Change body parsing behaviour such that calls to 'next' don't result in POST request bodies disappearing (#147).
-* (Internal) Remove unused type RequestBodyState (#313)
+* Drop support for GHC < 8.10 and modernise the CI pipeline (#300).
+* Adds a new `nested` handler that allows you to place an entire WAI Application under a Scotty route (#233).
+* Disambiguate request parameters (#204). Adjust the `Env` type to have three `[Param]` fields instead of one, add `captureParam`, `formParam`, `queryParam` and the associated `captureParams`, `formParams`, `queryParams`. Add deprecation notices to `param` and `params`.
+* Add `Scotty.Cookie` module (#293).
+* Change body parsing behaviour such that calls to `next` don't result in POST request bodies disappearing (#147).
+* (Internal) Remove unused type `RequestBodyState` (#313)
+
+### Breaking:
 * Get rid of data-default-class (#316) https://markkarpov.com/post/data-default.html
+* (#314) Rewrite `ActionT` as a `ReaderT`-over-`IO` (using the "ReaderT pattern" : https://www.fpcomplete.com/blog/readert-design-pattern/ )
+* (#314) Introduce `unliftio-core` as a dependency, and base exception handling on methods copied from `unliftio` e.g. `catch`.
+* (#314) All ActionT methods (`text`, `html` etc.) have now a MonadIO constraint on the base monad rather than Monad. `rescue` has a MonadUnliftIO constraint. The Alternative instance of ActionT also is based on MonadIO because `next` is implemented in terms of `throw`.
 
 ## 0.12.1 [2022.11.17]
 * Fix CPP bug that prevented tests from building on Windows.

--- a/changelog.md
+++ b/changelog.md
@@ -7,13 +7,13 @@
 * Add `Scotty.Cookie` module (#293).
 * Change body parsing behaviour such that calls to `next` don't result in POST request bodies disappearing (#147).
 * (Internal) Remove unused type `RequestBodyState` (#313)
+* Rewrite `ActionT` using the "ReaderT pattern" (#310) https://www.fpcomplete.com/blog/readert-design-pattern/
 
 Breaking:
 
-* (#310) Rewrite `ActionT` using the "ReaderT pattern" : https://www.fpcomplete.com/blog/readert-design-pattern/
 * (#310) Introduce `unliftio` as a dependency, and base exception handling on `catch`.
-* (#310) Clarify the exception handling mechanism of ActionT, ScottyT. `rescue` changes signature to use proper `Exception` types rather than strings.
-* (#310) All ActionT methods (`text`, `html` etc.) have now a MonadIO constraint on the base monad rather than Monad because the response is in a TVar inside ActionEnv. `rescue` has a MonadUnliftIO constraint. The Alternative instance of ActionT also is based on MonadUnliftIO because `<|>` is implemented in terms of `catch`.
+** Clarify the exception handling mechanism of ActionT, ScottyT. `rescue` changes signature to use proper `Exception` types rather than strings.
+** All ActionT methods (`text`, `html` etc.) have now a MonadIO constraint on the base monad rather than Monad because the response is constructed in a TVar inside ActionEnv. `rescue` has a MonadUnliftIO constraint. The Alternative instance of ActionT also is based on MonadUnliftIO because `<|>` is implemented in terms of `catch`. `ScottyT` and `ActionT` do not have an exception type parameter anymore.
 
 ## 0.12.1 [2022.11.17]
 * Fix CPP bug that prevented tests from building on Windows.

--- a/changelog.md
+++ b/changelog.md
@@ -6,11 +6,11 @@
 * Change body parsing behaviour such that calls to `next` don't result in POST request bodies disappearing (#147).
 * (Internal) Remove unused type `RequestBodyState` (#313)
 
-### Breaking:
+Breaking:
 * Get rid of data-default-class (#316) https://markkarpov.com/post/data-default.html
-* (#314) Rewrite `ActionT` as a `ReaderT`-over-`IO` (using the "ReaderT pattern" : https://www.fpcomplete.com/blog/readert-design-pattern/ )
-* (#314) Introduce `unliftio-core` as a dependency, and base exception handling on methods copied from `unliftio` e.g. `catch`.
-* (#314) All ActionT methods (`text`, `html` etc.) have now a MonadIO constraint on the base monad rather than Monad. `rescue` has a MonadUnliftIO constraint. The Alternative instance of ActionT also is based on MonadIO because `next` is implemented in terms of `throw`.
+* (#310) Rewrite `ActionT` as a `ReaderT`-over-`IO` (using the "ReaderT pattern" : https://www.fpcomplete.com/blog/readert-design-pattern/ )
+* (#310) Introduce `unliftio-core` as a dependency, and base exception handling on methods copied from `unliftio` e.g. `catch`.
+* (#310) All ActionT methods (`text`, `html` etc.) have now a MonadIO constraint on the base monad rather than Monad. `rescue` has a MonadUnliftIO constraint. The Alternative instance of ActionT also is based on MonadIO because `next` is implemented in terms of `throw`.
 
 ## 0.12.1 [2022.11.17]
 * Fix CPP bug that prevented tests from building on Windows.

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,6 @@
 ## next [????.??.??]
+
+## 0.20 [2023.10.02]
 * Drop support for GHC < 8.10 and modernise the CI pipeline (#300).
 * Adds a new `nested` handler that allows you to place an entire WAI Application under a Scotty route (#233).
 * Disambiguate request parameters (#204). Adjust the `Env` type to have three `[Param]` fields instead of one, add `captureParam`, `formParam`, `queryParam` and the associated `captureParams`, `formParams`, `queryParams`. Add deprecation notices to `param` and `params`.
@@ -7,10 +9,12 @@
 * (Internal) Remove unused type `RequestBodyState` (#313)
 
 Breaking:
-* Get rid of data-default-class (#316) https://markkarpov.com/post/data-default.html
+
 * (#310) Rewrite `ActionT` as a `ReaderT`-over-`IO` (using the "ReaderT pattern" : https://www.fpcomplete.com/blog/readert-design-pattern/ )
 * (#310) Introduce `unliftio-core` as a dependency, and base exception handling on methods copied from `unliftio` e.g. `catch`.
+* (#310) Clarify the exception handling mechanism of ActionT, ScottyT. `raise` and `rescue` change signature to use proper `Exception` types rather than strings.
 * (#310) All ActionT methods (`text`, `html` etc.) have now a MonadIO constraint on the base monad rather than Monad. `rescue` has a MonadUnliftIO constraint. The Alternative instance of ActionT also is based on MonadIO because `next` is implemented in terms of `throw`.
+* Get rid of data-default-class (#316)
 
 ## 0.12.1 [2022.11.17]
 * Fix CPP bug that prevented tests from building on Windows.

--- a/changelog.md
+++ b/changelog.md
@@ -10,10 +10,10 @@
 
 Breaking:
 
-* (#310) Rewrite `ActionT` as a `ReaderT`-over-`IO` (using the "ReaderT pattern" : https://www.fpcomplete.com/blog/readert-design-pattern/ )
+* (#310) Rewrite `ActionT` using the "ReaderT pattern" : https://www.fpcomplete.com/blog/readert-design-pattern/
 * (#310) Introduce `unliftio-core` as a dependency, and base exception handling on methods copied from `unliftio` e.g. `catch`.
 * (#310) Clarify the exception handling mechanism of ActionT, ScottyT. `raise` and `rescue` change signature to use proper `Exception` types rather than strings.
-* (#310) All ActionT methods (`text`, `html` etc.) have now a MonadIO constraint on the base monad rather than Monad. `rescue` has a MonadUnliftIO constraint. The Alternative instance of ActionT also is based on MonadIO because `next` is implemented in terms of `throw`.
+* (#310) All ActionT methods (`text`, `html` etc.) have now a MonadIO constraint on the base monad rather than Monad because the response is in a TVar inside ActionEnv. `rescue` has a MonadUnliftIO constraint. The Alternative instance of ActionT also is based on MonadUnliftIO because `<|>` is implemented in terms of `catch`.
 * Get rid of data-default-class (#316)
 
 ## 0.12.1 [2022.11.17]

--- a/changelog.md
+++ b/changelog.md
@@ -11,8 +11,8 @@
 Breaking:
 
 * (#310) Rewrite `ActionT` using the "ReaderT pattern" : https://www.fpcomplete.com/blog/readert-design-pattern/
-* (#310) Introduce `unliftio-core` as a dependency, and base exception handling on methods copied from `unliftio` e.g. `catch`.
-* (#310) Clarify the exception handling mechanism of ActionT, ScottyT. `raise` and `rescue` change signature to use proper `Exception` types rather than strings.
+* (#310) Introduce `unliftio` as a dependency, and base exception handling on `catch`.
+* (#310) Clarify the exception handling mechanism of ActionT, ScottyT. `rescue` changes signature to use proper `Exception` types rather than strings.
 * (#310) All ActionT methods (`text`, `html` etc.) have now a MonadIO constraint on the base monad rather than Monad because the response is in a TVar inside ActionEnv. `rescue` has a MonadUnliftIO constraint. The Alternative instance of ActionT also is based on MonadUnliftIO because `<|>` is implemented in terms of `catch`.
 
 ## 0.12.1 [2022.11.17]

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 * Add `Scotty.Cookie` module.
 * Change body parsing behaviour such that calls to 'next' don't result in POST request bodies disappearing (#147).
 * (Internal) Remove unused type RequestBodyState (#313)
+* Get rid of data-default-class (#316) https://markkarpov.com/post/data-default.html
 
 ## 0.12.1 [2022.11.17]
 * Fix CPP bug that prevented tests from building on Windows.

--- a/changelog.md
+++ b/changelog.md
@@ -14,7 +14,6 @@ Breaking:
 * (#310) Introduce `unliftio-core` as a dependency, and base exception handling on methods copied from `unliftio` e.g. `catch`.
 * (#310) Clarify the exception handling mechanism of ActionT, ScottyT. `raise` and `rescue` change signature to use proper `Exception` types rather than strings.
 * (#310) All ActionT methods (`text`, `html` etc.) have now a MonadIO constraint on the base monad rather than Monad because the response is in a TVar inside ActionEnv. `rescue` has a MonadUnliftIO constraint. The Alternative instance of ActionT also is based on MonadUnliftIO because `<|>` is implemented in terms of `catch`.
-* Get rid of data-default-class (#316)
 
 ## 0.12.1 [2022.11.17]
 * Fix CPP bug that prevented tests from building on Windows.

--- a/examples/basic.hs
+++ b/examples/basic.hs
@@ -44,7 +44,7 @@ main = scotty 3000 $ do
         html $ mconcat ["<h1>", v, "</h1>"]
 
     -- An uncaught error becomes a 500 page.
-    get "/raise" $ raise Boom
+    get "/raise" $ throw Boom
 
     -- You can set status and headers directly.
     get "/redirect-custom" $ do
@@ -55,11 +55,11 @@ main = scotty 3000 $ do
     -- redirects preempt execution
     get "/redirect" $ do
         void $ redirect "http://www.google.com"
-        raise NeverReached
+        throw NeverReached
 
     -- Of course you can catch your own errors.
     get "/rescue" $ do
-        (do void $ raise Boom; redirect "http://www.we-never-go-here.com")
+        (do void $ throw Boom; redirect "http://www.we-never-go-here.com")
         `rescue` (\(e :: Err) -> text $ "we recovered from " `mappend` pack (show e))
 
     -- Parts of the URL that start with a colon match
@@ -101,7 +101,7 @@ main = scotty 3000 $ do
     -- Look up a request header
     get "/header" $ do
         agent <- header "User-Agent"
-        maybe (raise UserAgentNotFound) text agent
+        maybe (throw UserAgentNotFound) text agent
 
     -- Make a request to this URI, then type a line in the terminal, which
     -- will be the response. Using ctrl-c will cause getLine to fail.

--- a/examples/basic.hs
+++ b/examples/basic.hs
@@ -37,7 +37,7 @@ main = scotty 3000 $ do
     get "/" $ text "foobar"
     get "/" $ text "barfoo"
 
-    -- Using a parameter in the query string. If it has
+    -- Using a parameter in the query string. Since it has
     -- not been given, a 500 page is generated.
     get "/foo" $ do
         v <- captureParam "fooparam"
@@ -72,7 +72,7 @@ main = scotty 3000 $ do
     -- Files are streamed directly to the client.
     get "/404" $ file "404.html"
 
-    -- You can stop execution of this action and keep pattern matching routes.
+    -- 'next' stops execution of the current action and keeps pattern matching routes.
     get "/random" $ do
         void next
         redirect "http://www.we-never-go-here.com"
@@ -106,6 +106,8 @@ main = scotty 3000 $ do
     -- Make a request to this URI, then type a line in the terminal, which
     -- will be the response. Using ctrl-c will cause getLine to fail.
     -- This demonstrates that IO exceptions are lifted into ActionM exceptions.
+    --
+    -- (#310) we don't catch async exceptions, so ctrl-c just exits the program
     get "/iofail" $ do
         msg <- liftIO $ liftM fromString getLine
         text msg

--- a/examples/basic.hs
+++ b/examples/basic.hs
@@ -52,7 +52,7 @@ main = scotty 3000 $ do
     -- Of course you can catch your own errors.
     get "/rescue" $ do
         (do void $ raise "a rescued error"; redirect "http://www.we-never-go-here.com")
-        `rescue` (\m -> text $ "we recovered from " `mappend` m)
+        `rescue` (\m -> text $ "we recovered from " `mappend` aErrText m)
 
     -- Parts of the URL that start with a colon match
     -- any string, and capture that value as a parameter.

--- a/examples/exceptions.hs
+++ b/examples/exceptions.hs
@@ -26,7 +26,7 @@ instance ScottyError Except where
     showError = fromString . show
 
 -- Handler for uncaught exceptions.
-handleEx :: Monad m => Except -> ActionT Except m ()
+handleEx :: Monad m => Except -> ActionT m ()
 handleEx Forbidden    = do
     status status403
     html "<h1>Scotty Says No</h1>"

--- a/examples/exceptions.hs
+++ b/examples/exceptions.hs
@@ -1,9 +1,13 @@
 {-# LANGUAGE OverloadedStrings, GeneralizedNewtypeDeriving, ScopedTypeVariables #-}
+{-# language DeriveAnyClass #-}
+{-# language LambdaCase #-}
 module Main (main) where
 
+import Control.Exception (Exception(..))
 import Control.Monad.IO.Class
 
 import Data.String (fromString)
+import Data.Typeable
 
 import Network.HTTP.Types
 import Network.Wai.Middleware.RequestLogger
@@ -15,25 +19,20 @@ import System.Random
 
 import Web.Scotty.Trans
 
--- Define a custom exception type.
+-- | A custom exception type.
 data Except = Forbidden | NotFound Int | StringEx String
-    deriving (Show, Eq)
+    deriving (Show, Eq, Typeable, Exception)
 
--- The type must be an instance of 'ScottyError'.
--- 'ScottyError' is essentially a combination of 'Error' and 'Show'.
-instance ScottyError Except where
-    stringError = StringEx
-    showError = fromString . show
-
--- Handler for uncaught exceptions.
-handleEx :: Monad m => Except -> ActionT m ()
-handleEx Forbidden    = do
+-- | User-defined exceptions should have an associated Handler:
+handleEx :: MonadIO m => ErrorHandler m
+handleEx = Handler $ \case
+  Forbidden -> do
     status status403
     html "<h1>Scotty Says No</h1>"
-handleEx (NotFound i) = do
+  NotFound i -> do
     status status404
     html $ fromString $ "<h1>Can't find " ++ show i ++ ".</h1>"
-handleEx (StringEx s) = do
+  StringEx s -> do
     status status500
     html $ fromString $ "<h1>" ++ s ++ "</h1>"
 

--- a/examples/exceptions.hs
+++ b/examples/exceptions.hs
@@ -53,12 +53,12 @@ main = scottyT 3000 id $ do -- note, we aren't using any additional transformer 
 
     get "/switch/:val" $ do
         v <- captureParam "val"
-        _ <- if even v then raise Forbidden else raise (NotFound v)
+        _ <- if even v then throw Forbidden else throw (NotFound v)
         text "this will never be reached"
 
     get "/random" $ do
         rBool <- liftIO randomIO
         i <- liftIO randomIO
         let catchOne Forbidden = html "<h1>Forbidden was randomly thrown, but we caught it."
-            catchOne other     = raise other
-        raise (if rBool then Forbidden else NotFound i) `rescue` catchOne
+            catchOne other     = throw other
+        throw (if rBool then Forbidden else NotFound i) `rescue` catchOne

--- a/examples/globalstate.hs
+++ b/examples/globalstate.hs
@@ -13,9 +13,7 @@ import Control.Concurrent.STM
 import Control.Monad.IO.Unlift (MonadUnliftIO(..))
 import Control.Monad.Reader
 
-import Data.Default.Class
 import Data.String
-import Data.Text.Lazy (Text)
 
 import Network.Wai.Middleware.RequestLogger
 
@@ -26,8 +24,8 @@ import Web.Scotty.Trans
 
 newtype AppState = AppState { tickCount :: Int }
 
-instance Default AppState where
-    def = AppState 0
+defaultAppState :: AppState
+defaultAppState = AppState 0
 
 -- Why 'ReaderT (TVar AppState)' rather than 'StateT AppState'?
 -- With a state transformer, 'runActionToIO' (below) would have
@@ -57,7 +55,7 @@ modify f = ask >>= liftIO . atomically . flip modifyTVar' f
 
 main :: IO ()
 main = do
-    sync <- newTVarIO def
+    sync <- newTVarIO defaultAppState
         -- 'runActionToIO' is called once per action.
     let runActionToIO m = runReaderT (runWebM m) sync
 

--- a/examples/globalstate.hs
+++ b/examples/globalstate.hs
@@ -10,6 +10,7 @@
 module Main (main) where
 
 import Control.Concurrent.STM
+import Control.Monad.IO.Unlift (MonadUnliftIO(..))
 import Control.Monad.Reader
 
 import Data.Default.Class
@@ -39,7 +40,7 @@ instance Default AppState where
 -- Also note: your monad must be an instance of 'MonadIO' for
 -- Scotty to use it.
 newtype WebM a = WebM { runWebM :: ReaderT (TVar AppState) IO a }
-    deriving (Applicative, Functor, Monad, MonadIO, MonadReader (TVar AppState))
+    deriving (Applicative, Functor, Monad, MonadIO, MonadReader (TVar AppState), MonadUnliftIO)
 
 -- Scotty's monads are layered on top of our custom monad.
 -- We define this synonym for lift in order to be explicit
@@ -66,7 +67,7 @@ main = do
 -- type is ambiguous. We can fix it by putting a type
 -- annotation just about anywhere. In this case, we'll
 -- just do it on the entire app.
-app :: ScottyT Text WebM ()
+app :: ScottyT WebM ()
 app = do
     middleware logStdoutDev
     get "/" $ do

--- a/examples/options.hs
+++ b/examples/options.hs
@@ -5,14 +5,13 @@ import Web.Scotty
 
 import Network.Wai.Middleware.RequestLogger -- install wai-extra if you don't have this
 
-import Data.Default.Class (def)
 import Network.Wai.Handler.Warp (setPort)
 
 -- Set some Scotty settings
 opts :: Options
-opts = def { verbose = 0
-           , settings = setPort 4000 $ settings def
-           }
+opts = defaultOptions { verbose = 0
+                      , settings = setPort 4000 $ settings defaultOptions
+                      }
 
 -- This won't display anything at startup, and will listen on localhost:4000
 main :: IO ()

--- a/examples/reader.hs
+++ b/examples/reader.hs
@@ -9,7 +9,7 @@ module Main where
 
 import Control.Monad.Reader (MonadIO, MonadReader, ReaderT, asks, lift, runReaderT)
 import Control.Monad.IO.Unlift (MonadUnliftIO(..))
-import Data.Text.Lazy (Text, pack)
+import Data.Text.Lazy (pack)
 import Prelude ()
 import Prelude.Compat
 import Web.Scotty.Trans (ScottyT, defaultOptions, get, scottyOptsT, text)

--- a/examples/reader.hs
+++ b/examples/reader.hs
@@ -8,11 +8,11 @@
 module Main where
 
 import Control.Monad.Reader (MonadIO, MonadReader, ReaderT, asks, lift, runReaderT)
-import Data.Default.Class (def)
+import Control.Monad.IO.Unlift (MonadUnliftIO(..))
 import Data.Text.Lazy (Text, pack)
 import Prelude ()
 import Prelude.Compat
-import Web.Scotty.Trans (ScottyT, get, scottyOptsT, text)
+import Web.Scotty.Trans (ScottyT, defaultOptions, get, scottyOptsT, text)
 
 data Config = Config
   { environment :: String
@@ -20,16 +20,16 @@ data Config = Config
 
 newtype ConfigM a = ConfigM
   { runConfigM :: ReaderT Config IO a
-  } deriving (Applicative, Functor, Monad, MonadIO, MonadReader Config)
+  } deriving (Applicative, Functor, Monad, MonadIO, MonadReader Config, MonadUnliftIO)
 
-application :: ScottyT Text ConfigM ()
+application :: ScottyT ConfigM ()
 application = do
   get "/" $ do
     e <- lift $ asks environment
     text $ pack $ show e
 
 main :: IO ()
-main = scottyOptsT def runIO application where
+main = scottyOptsT defaultOptions runIO application where
   runIO :: ConfigM a -> IO a
   runIO m = runReaderT (runConfigM m) config
 

--- a/examples/scotty-examples.cabal
+++ b/examples/scotty-examples.cabal
@@ -88,6 +88,7 @@ executable scotty-globalstate
                        stm,
                        text,
                        transformers,
+                       unliftio-core >= 0.2,
                        wai-extra
   GHC-options:         -Wall -threaded
 
@@ -117,10 +118,10 @@ executable scotty-reader
   hs-source-dirs:      .
   build-depends:       base >= 4.6 && < 5,
                        base-compat >= 0.11 && < 0.13,
-                       data-default-class,
                        mtl,
                        scotty,
-                       text
+                       text,
+                       unliftio-core >= 0.2
   GHC-options:         -Wall -threaded
 
 executable scotty-upload

--- a/examples/scotty-examples.cabal
+++ b/examples/scotty-examples.cabal
@@ -82,7 +82,6 @@ executable scotty-globalstate
   hs-source-dirs:      .
   build-depends:       base >= 4.6 && < 5,
                        base-compat >= 0.11 && < 0.13,
-                       data-default-class,
                        mtl,
                        scotty,
                        stm,
@@ -106,7 +105,6 @@ executable scotty-options
   default-language:    Haskell2010
   hs-source-dirs:      .
   build-depends:       base >= 4.6 && < 5,
-                       data-default-class,
                        scotty,
                        wai-extra,
                        warp

--- a/examples/urlshortener.hs
+++ b/examples/urlshortener.hs
@@ -28,7 +28,7 @@ import Text.Blaze.Html5.Attributes
 import Text.Blaze.Html.Renderer.Text (renderHtml)
 
 -- TODO:
--- Implement some kind of session and/or cookies
+-- Implement some kind of session (#317) and/or cookies
 -- Add links
 
 data SessionError = UrlHashNotFound Int deriving (Typeable, Exception)

--- a/examples/urlshortener.hs
+++ b/examples/urlshortener.hs
@@ -65,7 +65,7 @@ main = do
         hash <- captureParam "hash"
         (_,db) <- liftIO $ readMVar m
         case M.lookup hash db of
-            Nothing -> raise $ UrlHashNotFound hash
+            Nothing -> throw $ UrlHashNotFound hash
             Just url -> redirect url
 
     -- We put /list down here to show that it will not match the '/:hash' route above.

--- a/scotty.cabal
+++ b/scotty.cabal
@@ -83,6 +83,7 @@ Library
                        mtl                   >= 2.1.2    && < 2.4,
                        network               >= 2.6.0.2  && < 3.2,
                        regex-compat          >= 0.95.1   && < 0.96,
+                       stm,
                        text                  >= 0.11.3.1 && < 2.1,
                        time                  >= 1.8,
                        transformers          >= 0.3.0.0  && < 0.7,

--- a/scotty.cabal
+++ b/scotty.cabal
@@ -1,13 +1,13 @@
 Name:                scotty
-Version:             0.12.1
+Version:             0.20
 Synopsis:            Haskell web framework inspired by Ruby's Sinatra, using WAI and Warp
 Homepage:            https://github.com/scotty-web/scotty
 Bug-reports:         https://github.com/scotty-web/scotty/issues
 License:             BSD3
 License-file:        LICENSE
 Author:              Andrew Farmer <xichekolas@gmail.com>
-Maintainer:          Andrew Farmer <xichekolas@gmail.com> and the Scotty maintainers
-Copyright:           (c) 2012-Present Andrew Farmer
+Maintainer:          The Scotty maintainers
+Copyright:           (c) 2012-Present Andrew Farmer and the Scotty maintainers
 Category:            Web
 Stability:           experimental
 Build-type:          Simple

--- a/scotty.cabal
+++ b/scotty.cabal
@@ -89,6 +89,7 @@ Library
                        transformers          >= 0.3.0.0  && < 0.7,
                        transformers-base     >= 0.4.1    && < 0.5,
                        transformers-compat   >= 0.4      && < 0.8,
+                       unliftio-core >= 0.2,
                        wai                   >= 3.0.0    && < 3.3,
                        wai-extra             >= 3.0.0    && < 3.2,
                        warp                  >= 3.0.13   && < 3.4

--- a/scotty.cabal
+++ b/scotty.cabal
@@ -7,7 +7,7 @@ License:             BSD3
 License-file:        LICENSE
 Author:              Andrew Farmer <xichekolas@gmail.com>
 Maintainer:          The Scotty maintainers
-Copyright:           (c) 2012-Present Andrew Farmer and the Scotty maintainers
+Copyright:           (c) 2012-Present, Andrew Farmer and the Scotty contributors
 Category:            Web
 Stability:           experimental
 Build-type:          Simple
@@ -19,8 +19,6 @@ Description:
     &#123;-&#35; LANGUAGE OverloadedStrings &#35;-&#125;
     .
     import Web.Scotty
-    .
-    import Data.Monoid (mconcat)
     .
     main = scotty 3000 $
     &#32;&#32;get &#34;/:word&#34; $ do

--- a/scotty.cabal
+++ b/scotty.cabal
@@ -77,6 +77,7 @@ Library
                        bytestring            >= 0.10.0.2 && < 0.12,
                        case-insensitive      >= 1.0.0.1  && < 1.3,
                        cookie                >= 0.4,
+                       data-default-class >= 0.1,
                        exceptions            >= 0.7      && < 0.11,
                        http-types            >= 0.9.1    && < 0.13,
                        monad-control         >= 1.0.0.3  && < 1.1,

--- a/scotty.cabal
+++ b/scotty.cabal
@@ -90,7 +90,7 @@ Library
                        transformers          >= 0.3.0.0  && < 0.7,
                        transformers-base     >= 0.4.1    && < 0.5,
                        transformers-compat   >= 0.4      && < 0.8,
-                       unliftio-core >= 0.2,
+                       unliftio >= 0.2,
                        wai                   >= 3.0.0    && < 3.3,
                        wai-extra             >= 3.0.0    && < 3.2,
                        warp                  >= 3.0.13   && < 3.4

--- a/scotty.cabal
+++ b/scotty.cabal
@@ -66,6 +66,7 @@ Library
                        Web.Scotty.Cookie
   other-modules:       Web.Scotty.Action
                        Web.Scotty.Body
+                       Web.Scotty.Exceptions
                        Web.Scotty.Route
                        Web.Scotty.Util
   default-language:    Haskell2010

--- a/scotty.cabal
+++ b/scotty.cabal
@@ -77,7 +77,6 @@ Library
                        bytestring            >= 0.10.0.2 && < 0.12,
                        case-insensitive      >= 1.0.0.1  && < 1.3,
                        cookie                >= 0.4,
-                       data-default-class    >= 0.0.1    && < 0.2,
                        exceptions            >= 0.7      && < 0.11,
                        http-types            >= 0.9.1    && < 0.13,
                        monad-control         >= 1.0.0.3  && < 1.1,
@@ -112,7 +111,6 @@ test-suite spec
   build-depends:       async,
                        base,
                        bytestring,
-                       data-default-class,
                        directory,
                        hspec == 2.*,
                        hspec-wai >= 0.6.3,
@@ -137,7 +135,6 @@ benchmark weigh
                        mtl,
                        text,
                        transformers,
-                       data-default-class,
                        weigh >= 0.0.16 && <0.1
   GHC-options:         -Wall -O2 -threaded
 

--- a/test/Web/ScottySpec.hs
+++ b/test/Web/ScottySpec.hs
@@ -24,7 +24,6 @@ import           Control.Concurrent.Async (withAsync)
 import           Control.Exception (bracketOnError)
 import qualified Data.ByteString as BS
 import           Data.ByteString (ByteString)
-import           Data.Default.Class (def)
 import           Network.Socket (Family(..), SockAddr(..), Socket, SocketOption(..), SocketType(..), bind, close, connect, listen, maxListenQueue, setSocketOption, socket)
 import           Network.Socket.ByteString (send, recv)
 import           System.Directory (removeFile)
@@ -83,10 +82,10 @@ spec = do
           it "returns 404 when no route matches" $ do
             get "/" `shouldRespondWith` "<h1>404: File Not Found!</h1>" {matchStatus = 404}
 
-    describe "defaultHandler" $ do
-      withApp (defaultHandler text >> Scotty.get "/" (liftAndCatchIO $ E.throwIO E.DivideByZero)) $ do
-        it "sets custom exception handler" $ do
-          get "/" `shouldRespondWith` "divide by zero" {matchStatus = 500}
+    -- describe "defaultHandler" $ do
+    --   withApp (defaultHandler text >> Scotty.get "/" (liftAndCatchIO $ E.throwIO E.DivideByZero)) $ do
+    --     it "sets custom exception handler" $ do
+    --       get "/" `shouldRespondWith` "divide by zero" {matchStatus = 500}
 
       withApp (defaultHandler (\_ -> status status503) >> Scotty.get "/" (liftAndCatchIO $ E.throwIO E.DivideByZero)) $ do
         it "allows to customize the HTTP status code" $ do
@@ -296,7 +295,7 @@ withServer :: ScottyM () -> IO a -> IO a
 withServer actions inner = E.bracket
   (listenOn socketPath)
   (\sock -> close sock >> removeFile socketPath)
-  (\sock -> withAsync (Scotty.scottySocket def sock actions) $ const inner)
+  (\sock -> withAsync (Scotty.scottySocket defaultOptions sock actions) $ const inner)
 
 -- See https://github.com/haskell/network/issues/318
 listenOn :: String -> IO Socket

--- a/test/Web/ScottySpec.hs
+++ b/test/Web/ScottySpec.hs
@@ -5,6 +5,7 @@ import           Test.Hspec
 import           Test.Hspec.Wai
 
 import           Control.Applicative
+import qualified Control.Exception as E
 import           Control.Monad
 import           Data.Char
 import           Data.String
@@ -87,7 +88,11 @@ spec = do
     --     it "sets custom exception handler" $ do
     --       get "/" `shouldRespondWith` "divide by zero" {matchStatus = 500}
 
-      withApp (defaultHandler (\_ -> status status503) >> Scotty.get "/" (liftAndCatchIO $ E.throwIO E.DivideByZero)) $ do
+    describe "defaultHandler" $ do
+      withApp (do
+                  let h = Handler (\(e :: E.ArithException) -> status status503)
+                  defaultHandler h
+                  Scotty.get "/" (liftAndCatchIO $ E.throwIO E.DivideByZero)) $ do
         it "allows to customize the HTTP status code" $ do
           get "/" `shouldRespondWith` "" {matchStatus = 503}
 

--- a/test/Web/ScottySpec.hs
+++ b/test/Web/ScottySpec.hs
@@ -83,12 +83,13 @@ spec = do
           it "returns 404 when no route matches" $ do
             get "/" `shouldRespondWith` "<h1>404: File Not Found!</h1>" {matchStatus = 404}
 
-    -- describe "defaultHandler" $ do
-    --   withApp (defaultHandler text >> Scotty.get "/" (liftAndCatchIO $ E.throwIO E.DivideByZero)) $ do
-    --     it "sets custom exception handler" $ do
-    --       get "/" `shouldRespondWith` "divide by zero" {matchStatus = 500}
-
     describe "defaultHandler" $ do
+      withApp (do
+                  let h = Handler (\(e :: E.ArithException) -> text (TL.pack $ show e))
+                  defaultHandler h
+                  Scotty.get "/" (liftAndCatchIO $ E.throwIO E.DivideByZero)) $ do
+        it "sets custom exception handler" $ do
+          get "/" `shouldRespondWith` "divide by zero" {matchStatus = 500}
       withApp (do
                   let h = Handler (\(e :: E.ArithException) -> status status503)
                   defaultHandler h

--- a/test/Web/ScottySpec.hs
+++ b/test/Web/ScottySpec.hs
@@ -130,6 +130,9 @@ spec = do
             get "/" `shouldRespondWith` "" {matchStatus = 500}
 
     context "Alternative instance" $ do
+      withApp (Scotty.get "/" $ empty >>= text) $
+        it "empty without any route following returns a 404" $
+          get "/" `shouldRespondWith` 404
       withApp (Scotty.get "/dictionary" $ empty <|> queryParam "word1" >>= text) $
         it "empty throws Next" $ do
           get "/dictionary?word1=x" `shouldRespondWith` "x"
@@ -137,6 +140,14 @@ spec = do
         it "<|> skips the left route if that fails" $ do
           get "/dictionary?word2=y" `shouldRespondWith` "y"
           get "/dictionary?word1=a&word2=b" `shouldRespondWith` "a"
+
+    describe "redirect" $ do
+      withApp (
+        do
+          Scotty.get "/a" $ redirect "/b"
+              ) $ do
+        it "Responds with a 302 Redirect" $ do
+          get "/a" `shouldRespondWith` 302
 
     describe "captureParam" $ do
       withApp (

--- a/test/Web/ScottySpec.hs
+++ b/test/Web/ScottySpec.hs
@@ -86,7 +86,7 @@ spec = do
       withApp (do
                   let h = Handler (\(e :: E.ArithException) -> status status500 >> text (TL.pack $ show e))
                   defaultHandler h
-                  Scotty.get "/" (raise E.DivideByZero)) $ do
+                  Scotty.get "/" (throw E.DivideByZero)) $ do
         it "sets custom exception handler" $ do
           get "/" `shouldRespondWith` "divide by zero" {matchStatus = 500}
       withApp (do
@@ -97,7 +97,7 @@ spec = do
           get "/" `shouldRespondWith` "" {matchStatus = 503}
 
       context "when not specified" $ do
-        withApp (Scotty.get "/" $ raise E.DivideByZero) $ do
+        withApp (Scotty.get "/" $ throw E.DivideByZero) $ do
           it "returns 500 on exceptions" $ do
             get "/" `shouldRespondWith` "" {matchStatus = 500}
 


### PR DESCRIPTION
`scotty-0.20` : 

* Rewrite `ActionT` using the "ReaderT pattern" : https://www.fpcomplete.com/blog/readert-design-pattern/ 
* Clarify the exception handling mechanism of ActionT, ScottyT.  The `StatusError` type can be thrown and caught, but `Next`, `Finish` and `Redirect` cannot be caught by the user. For `StatusError` and any user-defined (or imported) exception types, one can either catch exceptions inline with `rescue` or globally for the whole app with `defaultHandler`.

# Breaking changes:

* Introduce `unliftio` as a dependency, and base exception handling on `catch`.
* `rescue` changes signature to use proper `Exception` types rather than strings.
* All ActionT methods (`text`, `html` etc.) have now a MonadIO constraint on the base monad rather than Monad because the Response is in a TVar inside `ActionEnv`. `rescue` has a MonadUnliftIO constraint.  The Alternative instance of ActionT is also based on MonadUnliftIO because `<|>` is implemented in terms of `catch`.

Closes #310 , closes #309 in passing

closes #110 , closes #153 

![image](https://github.com/scotty-web/scotty/assets/5902760/a61920c3-c9fd-405d-8db1-c9f73c2674c8)
