### PR TITLE
add Web.Scotty.Trans.Strict

### DIFF
--- a/Web/Scotty.hs
+++ b/Web/Scotty.hs
@@ -50,7 +50,7 @@ import Control.Monad.IO.Class
 import Data.Aeson (FromJSON, ToJSON)
 import qualified Data.ByteString as BS
 import Data.ByteString.Lazy.Char8 (ByteString)
-import Data.Text.Lazy (Text)
+import Data.Text.Lazy (Text, toStrict)
 
 import Network.HTTP.Types (Status, StdMethod, ResponseHeaders)
 import Network.Socket (Socket)
@@ -227,7 +227,7 @@ jsonData = Trans.jsonData
 --   This means captures are somewhat typed, in that a route won't match if a correctly typed
 --   capture cannot be parsed.
 param :: Trans.Parsable a => Text -> ActionM a
-param = Trans.param
+param = Trans.param . toStrict
 {-# DEPRECATED param "(#204) Not a good idea to treat all parameters identically. Use captureParam, formParam and queryParam instead. "#-}
 
 -- | Get a capture parameter.
@@ -238,7 +238,7 @@ param = Trans.param
 --
 -- /Since: 0.20/
 captureParam :: Trans.Parsable a => Text -> ActionM a
-captureParam = Trans.captureParam
+captureParam = Trans.captureParam . toStrict
 
 -- | Get a form parameter.
 --
@@ -248,7 +248,7 @@ captureParam = Trans.captureParam
 --
 -- /Since: 0.20/
 formParam :: Trans.Parsable a => Text -> ActionM a
-formParam = Trans.formParam
+formParam = Trans.formParam . toStrict
 
 -- | Get a query parameter.
 --
@@ -258,7 +258,7 @@ formParam = Trans.formParam
 --
 -- /Since: 0.20/
 queryParam :: Trans.Parsable a => Text -> ActionM a
-queryParam = Trans.queryParam
+queryParam = Trans.queryParam . toStrict
 
 
 -- | Look up a capture parameter. Returns 'Nothing' if the parameter is not found or cannot be parsed at the right type.
@@ -268,7 +268,7 @@ queryParam = Trans.queryParam
 --
 -- /Since: FIXME/
 captureParamMaybe :: (Trans.Parsable a) => Text -> ActionM (Maybe a)
-captureParamMaybe = Trans.captureParamMaybe
+captureParamMaybe = Trans.captureParamMaybe . toStrict
 
 -- | Look up a form parameter. Returns 'Nothing' if the parameter is not found or cannot be parsed at the right type.
 --
@@ -276,7 +276,7 @@ captureParamMaybe = Trans.captureParamMaybe
 --
 -- /Since: FIXME/
 formParamMaybe :: (Trans.Parsable a) => Text -> ActionM (Maybe a)
-formParamMaybe = Trans.formParamMaybe
+formParamMaybe = Trans.formParamMaybe . toStrict
 
 -- | Look up a query parameter. Returns 'Nothing' if the parameter is not found or cannot be parsed at the right type.
 --
@@ -284,7 +284,7 @@ formParamMaybe = Trans.formParamMaybe
 --
 -- /Since: FIXME/
 queryParamMaybe :: (Trans.Parsable a) => Text -> ActionM (Maybe a)
-queryParamMaybe = Trans.queryParamMaybe
+queryParamMaybe = Trans.queryParamMaybe . toStrict
 
 
 

--- a/Web/Scotty/Body.hs
+++ b/Web/Scotty/Body.hs
@@ -20,7 +20,7 @@ import           Network.Wai (Request(..), getRequestBodyChunk)
 import qualified Network.Wai.Parse as W (File, Param, getRequestBodyType, BackEnd, lbsBackEnd, sinkRequestBody)
 import           Web.Scotty.Action (Param)
 import           Web.Scotty.Internal.Types (BodyInfo(..), BodyChunkBuffer(..), BodyPartiallyStreamed(..), RouteOptions(..))
-import           Web.Scotty.Util (readRequestBody, strictByteStringToLazyText)
+import           Web.Scotty.Util (readRequestBody, strictByteStringToLazyText, decodeUtf8Lenient)
 
 -- | Make a new BodyInfo with readProgress at 0 and an empty BodyChunkBuffer.
 newBodyInfo :: (MonadIO m) => Request -> m BodyInfo
@@ -47,7 +47,7 @@ getFormParamsAndFilesAction req bodyInfo opts = do
       bs <- getBodyAction bodyInfo opts
       let wholeBody = BL.toChunks bs
       (formparams, fs) <- parseRequestBody wholeBody W.lbsBackEnd req -- NB this loads the whole body into memory
-      let convert (k, v) = (strictByteStringToLazyText k, strictByteStringToLazyText v)
+      let convert (k, v) = (decodeUtf8Lenient k, decodeUtf8Lenient v)
       return (convert <$> formparams, fs)
     else
     return ([], [])

--- a/Web/Scotty/Internal/Types.hs
+++ b/Web/Scotty/Internal/Types.hs
@@ -30,7 +30,7 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy.Char8 as LBS8 (ByteString)
 import           Data.Default.Class (Default, def)
 import           Data.String (IsString(..))
-import           Data.Text.Lazy (Text, pack)
+import           Data.Text (Text, pack)
 import           Data.Typeable (Typeable)
 
 import           Network.HTTP.Types

--- a/Web/Scotty/Trans.hs
+++ b/Web/Scotty/Trans.hs
@@ -22,23 +22,23 @@ module Web.Scotty.Trans
       -- ** Route Patterns
     , capture, regex, function, literal
       -- ** Accessing the Request, Captures, and Query Parameters
-    , request, header, headers, body, bodyReader
+    , request, Lazy.header, Lazy.headers, body, bodyReader
     , param, params
     , captureParam, formParam, queryParam
     , captureParamMaybe, formParamMaybe, queryParamMaybe
     , captureParams, formParams, queryParams
     , jsonData, files
       -- ** Modifying the Response and Redirecting
-    , status, addHeader, setHeader, redirect
+    , status, Lazy.addHeader, Lazy.setHeader, Lazy.redirect
       -- ** Setting Response Body
       --
       -- | Note: only one of these should be present in any given route
       -- definition, as they completely replace the current 'Response' body.
-    , text, html, file, json, stream, raw, nested
+    , Lazy.text, Lazy.html, file, json, stream, raw, nested
       -- ** Accessing the fields of the Response
     , getResponseHeaders, getResponseStatus, getResponseContent
       -- ** Exceptions
-    , raise, raiseStatus, throw, rescue, next, finish, defaultHandler, liftAndCatchIO
+    , Lazy.raise, Lazy.raiseStatus, throw, rescue, next, finish, defaultHandler, liftAndCatchIO
     , liftIO, catch
     , StatusError(..)
       -- * Parsing Parameters
@@ -64,7 +64,8 @@ import Network.Wai.Handler.Warp (Port, runSettings, runSettingsSocket, setPort, 
 
 import Web.Scotty.Action
 import Web.Scotty.Route
-import Web.Scotty.Internal.Types (ActionT(..), ScottyT(..), defaultScottyState, Application, RoutePattern, Options(..), defaultOptions, RouteOptions(..), defaultRouteOptions, ErrorHandler, Kilobytes, File, addMiddleware, setHandler, updateMaxRequestBodySize, routes, middlewares, ScottyException(..), ScottyState, defaultScottyState, StatusError(..), Content(..))
+import Web.Scotty.Internal.Types (ScottyT(..), defaultScottyState, Application, RoutePattern, Options(..), defaultOptions, RouteOptions(..), defaultRouteOptions, ErrorHandler, Kilobytes, File, addMiddleware, setHandler, updateMaxRequestBodySize, routes, middlewares, ScottyException(..), ScottyState, defaultScottyState, StatusError(..), Content(..))
+import Web.Scotty.Trans.Lazy as Lazy
 import Web.Scotty.Util (socketDescription)
 import Web.Scotty.Body (newBodyInfo)
 
@@ -152,3 +153,4 @@ middleware = ScottyT . modify . addMiddleware
 setMaxRequestBodySize :: Kilobytes -- ^ Request size limit
                       -> ScottyT m ()
 setMaxRequestBodySize i = assert (i > 0) $ ScottyT . modify . updateMaxRequestBodySize $ defaultRouteOptions { maxRequestBodySize = Just i }
+

--- a/Web/Scotty/Trans/Lazy.hs
+++ b/Web/Scotty/Trans/Lazy.hs
@@ -1,0 +1,59 @@
+module Web.Scotty.Trans.Lazy where
+
+import Control.Monad (join)
+import Control.Monad.IO.Class
+import Data.Bifunctor (bimap)
+import qualified Data.Text.Lazy as T
+  
+import Network.HTTP.Types (Status)
+
+import qualified Web.Scotty.Action as Base
+import Web.Scotty.Internal.Types
+
+-- | Throw a "500 Server Error" 'StatusError', which can be caught with 'rescue'.
+--
+-- Uncaught exceptions turn into HTTP 500 responses.
+raise :: (MonadIO m) =>
+         T.Text -- ^ Error text
+      -> ActionT m a
+raise  = Base.raise . T.toStrict
+
+-- | Throw a 'StatusError' exception that has an associated HTTP error code and can be caught with 'rescue'.
+--
+-- Uncaught exceptions turn into HTTP responses corresponding to the given status.
+raiseStatus :: Monad m => Status -> T.Text -> ActionT m a
+raiseStatus s = Base.raiseStatus s . T.toStrict
+
+-- | Redirect to given URL. Like throwing an uncatchable exception. Any code after the call to redirect
+-- will not be run.
+--
+-- > redirect "http://www.google.com"
+--
+-- OR
+--
+-- > redirect "/foo/bar"
+redirect :: (Monad m) => T.Text -> ActionT m a
+redirect = Base.redirect . T.toStrict
+
+-- | Get a request header. Header name is case-insensitive.
+header :: (Monad m) => T.Text -> ActionT m (Maybe T.Text)
+header h = fmap T.fromStrict <$> Base.header (T.toStrict h)
+
+-- | Get all the request headers. Header names are case-insensitive.
+headers :: (Monad m) => ActionT m [(T.Text, T.Text)]
+headers = map (join bimap T.fromStrict) <$> Base.headers
+
+-- | Add to the response headers. Header names are case-insensitive.
+addHeader :: MonadIO m => T.Text -> T.Text -> ActionT m ()
+addHeader k v = Base.addHeader (T.toStrict k) (T.toStrict v)
+
+-- | Set one of the response headers. Will override any previously set value for that header.
+-- Header names are case-insensitive.
+setHeader :: MonadIO m => T.Text -> T.Text -> ActionT m ()
+setHeader k v = Base.addHeader (T.toStrict k) (T.toStrict v)
+
+text :: (MonadIO m) => T.Text -> ActionT m ()
+text = Base.textLazy
+
+html :: (MonadIO m) => T.Text -> ActionT m ()
+html = Base.htmlLazy

--- a/Web/Scotty/Trans/Strict.hs
+++ b/Web/Scotty/Trans/Strict.hs
@@ -1,0 +1,55 @@
+-- | This module is essentially identical to 'Web.Scotty.Trans', except that 
+-- some functions take/return strict Text instead of the lazy ones.
+--
+-- It should be noted that most of the code snippets below depend on the
+-- OverloadedStrings language pragma.
+--
+-- The functions in this module allow an arbitrary monad to be embedded
+-- in Scotty's monad transformer stack in order that Scotty be combined
+-- with other DSLs.
+--
+-- Scotty is set up by default for development mode. For production servers,
+-- you will likely want to modify 'settings' and the 'defaultHandler'. See
+-- the comments on each of these functions for more information.
+module Web.Scotty.Trans.Strict
+    ( -- * scotty-to-WAI
+      scottyT, scottyAppT, scottyOptsT, scottySocketT, Options(..), defaultOptions
+      -- * Defining Middleware and Routes
+      --
+      -- | 'Middleware' and routes are run in the order in which they
+      -- are defined. All middleware is run first, followed by the first
+      -- route that matches. If no route matches, a 404 response is given.
+    , middleware, get, post, put, delete, patch, options, addroute, matchAny, notFound, setMaxRequestBodySize
+      -- ** Route Patterns
+    , capture, regex, function, literal
+      -- ** Accessing the Request, Captures, and Query Parameters
+    , request, Base.header, Base.headers, body, bodyReader
+    , param, params
+    , captureParam, formParam, queryParam
+    , captureParamMaybe, formParamMaybe, queryParamMaybe
+    , captureParams, formParams, queryParams
+    , jsonData, files
+      -- ** Modifying the Response and Redirecting
+    , status, Base.addHeader, Base.setHeader, Base.redirect
+      -- ** Setting Response Body
+      --
+      -- | Note: only one of these should be present in any given route
+      -- definition, as they completely replace the current 'Response' body.
+    , Base.text, Base.html, file, json, stream, raw, nested
+    , textLazy
+    , htmlLazy
+      -- ** Accessing the fields of the Response
+    , getResponseHeaders, getResponseStatus, getResponseContent
+      -- ** Exceptions
+    , Base.raise, Base.raiseStatus, throw, rescue, next, finish, defaultHandler, liftAndCatchIO
+    , StatusError(..)
+      -- * Parsing Parameters
+    , Param, Parsable(..), readEither
+      -- * Types
+    , RoutePattern, File, Content(..), Kilobytes, ErrorHandler, Handler(..)
+      -- * Monad Transformers
+    , ScottyT, ActionT
+    , ScottyState, defaultScottyState
+    ) where
+import Web.Scotty.Action as Base
+import Web.Scotty.Trans

--- a/Web/Scotty/Util.hs
+++ b/Web/Scotty/Util.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
 module Web.Scotty.Util
     ( lazyTextToStrictByteString
@@ -23,7 +24,7 @@ import Network.HTTP.Types
 import qualified Data.ByteString as B
 import qualified Data.Text as TP (Text, pack)
 import qualified Data.Text.Lazy as TL
-import qualified Data.Text.Encoding as ES
+import           Data.Text.Encoding as ES
 import qualified Data.Text.Encoding.Error as ES
 
 import Web.Scotty.Internal.Types
@@ -34,8 +35,10 @@ lazyTextToStrictByteString = ES.encodeUtf8 . TL.toStrict
 strictByteStringToLazyText :: B.ByteString -> TL.Text
 strictByteStringToLazyText = TL.fromStrict . ES.decodeUtf8With ES.lenientDecode
 
+#if !MIN_VERSION_text(2,0,0)
 decodeUtf8Lenient :: B.ByteString -> TP.Text
 decodeUtf8Lenient = ES.decodeUtf8With ES.lenientDecode
+#endif
 
 -- Note: we currently don't support responseRaw, which may be useful
 -- for websockets. However, we always read the request body, which

--- a/Web/Scotty/Util.hs
+++ b/Web/Scotty/Util.hs
@@ -2,6 +2,7 @@
 module Web.Scotty.Util
     ( lazyTextToStrictByteString
     , strictByteStringToLazyText
+    , decodeUtf8Lenient
     , mkResponse
     , replace
     , add
@@ -20,7 +21,7 @@ import qualified Control.Exception as EUnsafe (throw)
 import Network.HTTP.Types
 
 import qualified Data.ByteString as B
-import qualified Data.Text as TP (pack)
+import qualified Data.Text as TP (Text, pack)
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Encoding as ES
 import qualified Data.Text.Encoding.Error as ES
@@ -33,7 +34,8 @@ lazyTextToStrictByteString = ES.encodeUtf8 . TL.toStrict
 strictByteStringToLazyText :: B.ByteString -> TL.Text
 strictByteStringToLazyText = TL.fromStrict . ES.decodeUtf8With ES.lenientDecode
 
-
+decodeUtf8Lenient :: B.ByteString -> TP.Text
+decodeUtf8Lenient = ES.decodeUtf8With ES.lenientDecode
 
 -- Note: we currently don't support responseRaw, which may be useful
 -- for websockets. However, we always read the request body, which

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 * add getResponseHeaders, getResponseStatus, getResponseContent (#214)
 * add `captureParamMaybe`, `formParamMaybe`, `queryParamMaybe` (#322)
 * deprecate `rescue` and `liftAndCatchIO`
+* add `Web.Scotty.Trans.Strict` and `Web.Scotty.Trans.Lazy`
 
 ## 0.20.1 [2023.10.03]
 

--- a/examples/scotty-examples.cabal
+++ b/examples/scotty-examples.cabal
@@ -122,6 +122,7 @@ executable scotty-upload
                        bytestring,
                        filepath,
                        scotty,
+                       text,
                        transformers,
                        wai-extra,
                        wai-middleware-static

--- a/examples/upload.hs
+++ b/examples/upload.hs
@@ -4,6 +4,7 @@ module Main (main) where
 import Web.Scotty
 
 import Control.Monad.IO.Class
+import qualified Data.Text.Lazy as TL
 
 import Network.Wai.Middleware.RequestLogger
 import Network.Wai.Middleware.Static
@@ -39,7 +40,7 @@ main = scotty 3000 $ do
         -- write the files to disk, so they will be served by the static middleware
         liftIO $ sequence_ [ B.writeFile ("uploads" </> fn) fc | (_,fn,fc) <- fs' ]
         -- generate list of links to the files just uploaded
-        html $ mconcat [ mconcat [ fName
+        html $ mconcat [ mconcat [ TL.fromStrict fName
                                  , ": "
                                  , renderHtml $ H.a (H.toHtml fn) H.! (href $ H.toValue fn) >> H.br
                                  ]

--- a/scotty.cabal
+++ b/scotty.cabal
@@ -60,11 +60,13 @@ Extra-source-files:
 Library
   Exposed-modules:     Web.Scotty
                        Web.Scotty.Trans
+                       Web.Scotty.Trans.Strict
                        Web.Scotty.Internal.Types
                        Web.Scotty.Cookie
   other-modules:       Web.Scotty.Action
                        Web.Scotty.Body
                        Web.Scotty.Route
+                       Web.Scotty.Trans.Lazy
                        Web.Scotty.Util
   default-language:    Haskell2010
   build-depends:       aeson                 >= 0.6.2.1  && < 2.3,


### PR DESCRIPTION
One major annoyance with scotty is that some functions unnecessarily take/return lazy Text.

This PR adds a new module `Web.Scotty.Trans.Strict` which uses strict Text instead