### PR TITLE
Disallow crlf headers #92

### DIFF
--- a/Web/Scotty.hs
+++ b/Web/Scotty.hs
@@ -24,7 +24,12 @@ module Web.Scotty
     , pathParams, captureParams, formParams, queryParams
     , jsonData, files
       -- ** Modifying the Response and Redirecting
-    , status, addHeader, setHeader, redirect
+      -- *** Status
+    , status
+      -- *** Headers
+    , addHeader, setHeader
+    , addHeader1, setHeader1
+    , redirect
       -- ** Setting Response Body
       --
       -- | Note: only one of these should be present in any given route
@@ -357,6 +362,20 @@ addHeader = Trans.addHeader
 -- Header names are case-insensitive.
 setHeader :: Text -> Text -> ActionM ()
 setHeader = Trans.setHeader
+
+-- | Add to the response headers. Header names are case-insensitive.
+addHeader1 :: Text -- ^ Header name
+           -> Text -- ^ Header value. Only the first characters before a newline or carrier return are kept
+           -> ActionM ()
+addHeader1 = Trans.addHeader1
+
+-- | Set one of the response headers. Will override any previously set value for that header.
+-- Header names are case-insensitive.
+setHeader1 :: Text -- ^ Header name
+           -> Text -- ^ Header value. Only the first characters before a newline or carrier return are kept
+           -> ActionM ()
+setHeader1 = Trans.setHeader1
+
 
 -- | Set the body of the response to the given 'Text' value. Also sets \"Content-Type\"
 -- header to \"text/plain; charset=utf-8\" if it has not already been set.

--- a/Web/Scotty/Cookie.hs
+++ b/Web/Scotty/Cookie.hs
@@ -95,6 +95,7 @@ setCookie :: (MonadIO m)
           => SetCookie
           -> ActionT m ()
 setCookie = setCookieWith setHeader
+{-# DEPRECATED setCookie "uses setHeader which is unsafe (#92). Please use setCookie1 instead"#-}
 
 -- | Set a cookie, with full access to its options (see 'SetCookie')
 --
@@ -121,10 +122,11 @@ setSimpleCookie :: (MonadIO m)
                 -> Text -- ^ value
                 -> ActionT m ()
 setSimpleCookie n v = setCookie $ makeSimpleCookie n v
+{-# DEPRECATED setSimpleCookie "uses setHeader which is unsafe (#92). Please use setSimpleCookie1 instead"#-}
 
 -- | 'makeSimpleCookie' and 'setCookie1' combined.
 --
--- NB : sanitizes the cookie value by keeping only the first characters before '\r' or '\n'
+-- NB : sanitizes the cookie value by keeping only the first characters before '\r' or '\n' (#92)
 setSimpleCookie1 :: (MonadIO m)
                  => Text -- ^ name
                  -> Text -- ^ value

--- a/Web/Scotty/Internal/Types.hs
+++ b/Web/Scotty/Internal/Types.hs
@@ -27,8 +27,10 @@ import           Control.Monad.Trans.Class (MonadTrans(..))
 import           Control.Monad.Trans.Control (MonadBaseControl, MonadTransControl)
 
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BS8 (splitWith)
 import qualified Data.ByteString.Lazy.Char8 as LBS8 (ByteString)
 import           Data.Default.Class (Default, def)
+import Data.Maybe (listToMaybe)
 import           Data.String (IsString(..))
 import           Data.Text (Text, pack)
 import           Data.Typeable (Typeable)
@@ -206,6 +208,13 @@ setContent c sr = sr { srContent = c }
 
 setHeaderWith :: ([(HeaderName, BS.ByteString)] -> [(HeaderName, BS.ByteString)]) -> ScottyResponse -> ScottyResponse
 setHeaderWith f sr = sr { srHeaders = f (srHeaders sr) }
+
+-- | Take the first characters before either a Carrier Return ('\r') or Line Feed ('\n').
+-- This can be used to sanitize headers.
+splitAtCRLF :: BS.ByteString -> Maybe BS.ByteString
+splitAtCRLF = listToMaybe . BS8.splitWith (\c -> c == '\n' ||
+                                                 c == '\r'
+                                          )
 
 setStatus :: Status -> ScottyResponse -> ScottyResponse
 setStatus s sr = sr { srStatus = s }

--- a/Web/Scotty/Trans.hs
+++ b/Web/Scotty/Trans.hs
@@ -29,7 +29,12 @@ module Web.Scotty.Trans
     , pathParams, captureParams, formParams, queryParams
     , jsonData, files
       -- ** Modifying the Response and Redirecting
-    , status, Lazy.addHeader, Lazy.setHeader, Lazy.redirect
+      -- *** Status
+    , status
+      -- *** Headers
+    , Lazy.addHeader, Lazy.setHeader
+    , Lazy.addHeader1, Lazy.setHeader1
+    , Lazy.redirect
       -- ** Setting Response Body
       --
       -- | Note: only one of these should be present in any given route

--- a/Web/Scotty/Trans/Lazy.hs
+++ b/Web/Scotty/Trans/Lazy.hs
@@ -54,6 +54,17 @@ addHeader k v = Base.addHeader (T.toStrict k) (T.toStrict v)
 setHeader :: MonadIO m => T.Text -> T.Text -> ActionT m ()
 setHeader k v = Base.addHeader (T.toStrict k) (T.toStrict v)
 
+
+-- | Add to the response headers. Header names are case-insensitive.
+addHeader1 :: MonadIO m => T.Text -> T.Text -> ActionT m ()
+addHeader1 k v = Base.addHeader1 (T.toStrict k) (T.toStrict v)
+
+-- | Set one of the response headers. Will override any previously set value for that header.
+-- Header names are case-insensitive.
+setHeader1 :: MonadIO m => T.Text -> T.Text -> ActionT m ()
+setHeader1 k v = Base.addHeader1 (T.toStrict k) (T.toStrict v)
+
+
 text :: (MonadIO m) => T.Text -> ActionT m ()
 text = Base.textLazy
 

--- a/Web/Scotty/Trans/Lazy.hs
+++ b/Web/Scotty/Trans/Lazy.hs
@@ -48,11 +48,13 @@ headers = map (join bimap T.fromStrict) <$> Base.headers
 -- | Add to the response headers. Header names are case-insensitive.
 addHeader :: MonadIO m => T.Text -> T.Text -> ActionT m ()
 addHeader k v = Base.addHeader (T.toStrict k) (T.toStrict v)
+{-# DEPRECATED addHeader "does not validate header values which is potentially unsafe (#92). Please use addHeader1 instead"#-}
 
 -- | Set one of the response headers. Will override any previously set value for that header.
 -- Header names are case-insensitive.
 setHeader :: MonadIO m => T.Text -> T.Text -> ActionT m ()
 setHeader k v = Base.addHeader (T.toStrict k) (T.toStrict v)
+{-# DEPRECATED setHeader "does not validate header values which is potentially unsafe (#92). Please use setHeader1 instead"#-}
 
 
 -- | Add to the response headers. Header names are case-insensitive.

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,12 @@
 * Deprecate `StatusError`, `raise` and `raiseStatus` (#351)
 * Add doctest, refactor some inline examples into doctests (#353)
 * document "`defaultHandler` only applies to endpoints defined after it" (#237)
+* add `setHeader1`, `addHeader1`, deprecate `setHeader`, `addHeader` (#94)
+* add `setCookie1`, `setSimpleCookie1` (#94)
+
+Breaking:
+
+* `setCookie` uses `setHeader` rather than `addHeader` (as it should)
 
 ## 0.20.1 [2023.10.03]
 

--- a/changelog.md
+++ b/changelog.md
@@ -11,8 +11,8 @@
 * Deprecate `StatusError`, `raise` and `raiseStatus` (#351)
 * Add doctest, refactor some inline examples into doctests (#353)
 * document "`defaultHandler` only applies to endpoints defined after it" (#237)
-* add `setHeader1`, `addHeader1`, deprecate `setHeader`, `addHeader` (#94)
-* add `setCookie1`, `setSimpleCookie1` (#94)
+* add `setHeader1`, `addHeader1`, deprecate `setHeader`, `addHeader` (#92)
+* add `setCookie1`, `setSimpleCookie1` (#92)
 
 Breaking:
 

--- a/test/Web/ScottySpec.hs
+++ b/test/Web/ScottySpec.hs
@@ -329,7 +329,7 @@ spec = do
       withApp (Scotty.get "/" $ setHeader "foo" "bar") $ do
           it "sets a header" $ do
             get "/" `shouldRespondWith` 200 {matchHeaders = ["foo" <:> "bar"]}
-      context "disregards CR and/or LF which could lead to security issues (#94)" $ do
+      context "disregards CR and/or LF which could lead to security issues (#92)" $ do
         withApp (Scotty.get "/" $ setHeader "X-Foo" "Hey\r\nContent-Type: bla") $ do
           it "is vulnerable" $ do
             get "/" `shouldRespondWith` 200 {
@@ -342,7 +342,7 @@ spec = do
       withApp (Scotty.get "/" $ setHeader1 "foo" "bar") $ do
           it "sets a header" $ do
             get "/" `shouldRespondWith` 200 {matchHeaders = ["foo" <:> "bar"]}
-      context "strips CR and/or LF from header values (#94)" $ do
+      context "strips CR and/or LF from header values (#92)" $ do
         withApp (Scotty.get "/" $ setHeader1 "X-Foo" "Hey\r\nContent-Type: bla") $ do
           it "is not vulnerable" $ do
             get "/" `shouldRespondWith` 200 {


### PR DESCRIPTION
* add `setHeader1`, `addHeader1`
* deprecate `setHeader`, `addHeader` , `setCookie`, `setSimpleCookie`
* add `setCookie1`, `setSimpleCookie1` 
* add tests that demonstrate the potential vulnerability

Breaking:

* `setCookie` uses `setHeader` rather than `addHeader` (as it should)

closes #92  (I was tempted to leave this ticket open until March 22 next year so we can celebrate its 10th birthday..)