### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ import Web.Scotty
 
 main = scotty 3000 $
     get "/:word" $ do
-        beam <- pathParam "word"
+        beam <- captureParam "word"
         html $ mconcat ["<h1>Scotty, ", beam, " me up!</h1>"]
 ```
 


### PR DESCRIPTION
Hello,

While following the example in the README. When using `pathParam`, I encountered an error.

![image](https://github.com/scotty-web/scotty/assets/18203647/91c352df-f7e8-43fb-b080-404ff5d75586)

Simply changing `pathParam` to `captureParam` resolved the issue and the functionality worked as expected.

![image](https://github.com/scotty-web/scotty/assets/18203647/958676cb-b84a-43af-b80d-95b2c0447874)

should be easy to reproduce but here are the versions that i am using:

ghc version 9.8.1
stack version 2.15.3
cabal version 3.10.2.1