### PR TITLE
Update haskell setup and cache github actions

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -27,17 +27,17 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
-    - uses: haskell/actions/setup@v2
+    - uses: haskell-actions/setup@v2
       id: setup-haskell-cabal
       name: Setup Haskell
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}
-    - uses: actions/cache@v1
+    - uses: actions/cache@v4
       name: Cache ~/.cabal/store
       with:
         path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
-        key: ${{ runner.os }}-${{ matrix.ghc }}--${{ github.Shah }}-cache
+        key: ${{ runner.os }}-${{ matrix.ghc }}--${{ matrix.cabal }}-cache
     - name: Versions
       run: |
         cabal -V


### PR DESCRIPTION
Fixes #376

Question:

I saw that there was an interpolated value called `${{ github.Shah }}` but I couldn't find what it meant online, I though it was a typo of `sha` but it doesn't make much sense to have it in the cache key since that would mean that the cache would get rebuilt on every commit so I deleted it.