### PR TITLE
Fixed Cookie example from Cookie module

### DIFF
--- a/Web/Scotty/Cookie.hs
+++ b/Web/Scotty/Cookie.hs
@@ -22,7 +22,7 @@ import Data.Monoid
 import Data.Maybe
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Read as TL (decimal)
-import Web.Scotty (scotty, html)
+import Web.Scotty (scotty, html, get)
 import Web.Scotty.Cookie (getCookie, setSimpleCookie)
 
 main :: IO ()
@@ -30,7 +30,7 @@ main = scotty 3000 $
     get \"/\" $ do
         hits <- liftM (fromMaybe \"0\") $ 'getCookie' \"hits\"
         let hits' =
-              case TL.decimal hits of
+              case TL.decimal $ TL.fromStrict hits of
                 Right n -> TL.pack . show . (+1) $ (fst n :: Integer)
                 Left _  -> \"1\"
         'setSimpleCookie' \"hits\" $ TL.toStrict hits'

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,5 @@
 ## next [????.??.??]
-
+* Fixed cookie example from `Cookie` module documentation. `getCookie` Function would return strict variant of `Text`. Will convert it into lazy variant using `fromStrict`. 
 
 ### Breaking changes
 * Remove dependency on data-default class (#386). We have been exporting constants for default config values since 0.20, and this dependency was simply unnecessary.


### PR DESCRIPTION
## Issue Description:
The original example in the Web.Scotty.Cookie module encountered two primary issues that hindered its functionality:

1. The `get` function, was not included in the import list from the `Web.Scotty` module, leading to a missing function error.
2. The `getCookie` function was expected to return a `Lazy Text` type, but instead, it returned a strict Text type. This discrepancy caused a type mismatch with the `TL.decimal` function, which requires a Lazy Text type.

![Screenshot from 2024-03-27 23-53-00](https://github.com/scotty-web/scotty/assets/40828350/369a1669-9534-4276-8cab-1489a3848a47)

## Solution Implemented:

1. The `get` function has now been added to the import list within the `Web.Scotty.Cookie` module.
2. The code now includes a conversion from strict Text to Lazy Text using the `TL.fromStrict` function. This conversion aligns with the expected input type for the html function, thereby resolving the type mismatch issue.

![Screenshot from 2024-03-27 23-55-09](https://github.com/scotty-web/scotty/assets/40828350/c032a013-fb63-4a14-9deb-360b8f532fb2)

@ocramz 