### PR TITLE
Exposed simple cookie functions via Main interface.

### DIFF
--- a/Web/Scotty.hs
+++ b/Web/Scotty.hs
@@ -52,6 +52,7 @@ module Web.Scotty
       -- * Types
     , ScottyM, ActionM, RoutePattern, File, Content(..), Kilobytes, ErrorHandler, Handler(..)
     , ScottyState, defaultScottyState
+    , module Web.Scotty.Cookie
     ) where
 
 import qualified Web.Scotty.Trans as Trans
@@ -71,6 +72,7 @@ import qualified Network.Wai.Parse as W
 
 import Web.Scotty.Internal.Types (ScottyT, ActionT, ErrorHandler, Param, RoutePattern, Options, defaultOptions, File, Kilobytes, ScottyState, defaultScottyState, ScottyException, StatusError(..), Content(..))
 import UnliftIO.Exception (Handler(..), catch)
+import Web.Scotty.Cookie (setSimpleCookie,getCookie,getCookies,deleteCookie,makeSimpleCookie)
 
 {- $setup
 >>> :{

--- a/Web/Scotty.hs
+++ b/Web/Scotty.hs
@@ -52,7 +52,8 @@ module Web.Scotty
       -- * Types
     , ScottyM, ActionM, RoutePattern, File, Content(..), Kilobytes, ErrorHandler, Handler(..)
     , ScottyState, defaultScottyState
-    , module Web.Scotty.Cookie
+    -- ** Functions from Cookie module
+    , setSimpleCookie,getCookie,getCookies,deleteCookie,makeSimpleCookie
     ) where
 
 import qualified Web.Scotty.Trans as Trans

--- a/Web/Scotty/Trans.hs
+++ b/Web/Scotty/Trans.hs
@@ -60,6 +60,7 @@ module Web.Scotty.Trans
       -- * Monad Transformers
     , ScottyT, ActionT
     , ScottyState, defaultScottyState
+    , module Web.Scotty.Cookie
     ) where
 
 import Blaze.ByteString.Builder (fromByteString)
@@ -84,6 +85,7 @@ import Web.Scotty.Util (socketDescription)
 import Web.Scotty.Body (newBodyInfo)
 
 import UnliftIO.Exception (Handler(..), catch)
+import Web.Scotty.Cookie (setSimpleCookie,getCookie,getCookies,deleteCookie,makeSimpleCookie)
 
 
 -- | Run a scotty application using the warp server.

--- a/Web/Scotty/Trans.hs
+++ b/Web/Scotty/Trans.hs
@@ -60,7 +60,8 @@ module Web.Scotty.Trans
       -- * Monad Transformers
     , ScottyT, ActionT
     , ScottyState, defaultScottyState
-    , module Web.Scotty.Cookie
+    -- ** Functions from Cookie module
+    , setSimpleCookie,getCookie,getCookies,deleteCookie,makeSimpleCookie
     ) where
 
 import Blaze.ByteString.Builder (fromByteString)

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 ## next [????.??.??]
 
 * Fixed cookie example from `Cookie` module documentation. `getCookie` Function would return strict variant of `Text`. Will convert it into lazy variant using `fromStrict`. 
+* Exposed simple functions of `Cookie` module via `Web.Scotty` & `Web.Scotty.Trans`.
 
 ### Breaking changes
 * Remove dependency on data-default class (#386). We have been exporting constants for default config values since 0.20, and this dependency was simply unnecessary.

--- a/examples/cookies.hs
+++ b/examples/cookies.hs
@@ -5,10 +5,10 @@ module Main (main) where
 import Control.Monad (forM_)
 
 import qualified Text.Blaze.Html5 as H
-import Text.Blaze.Html5.Attributes
-import Text.Blaze.Html.Renderer.Text (renderHtml)
-import Web.Scotty
-import Web.Scotty.Cookie (CookiesText, setSimpleCookie, getCookies)
+import           Text.Blaze.Html5.Attributes
+import           Text.Blaze.Html.Renderer.Text (renderHtml)
+import           Web.Scotty -- Web.Scotty exports setSimpleCookie,getCookies
+import           Web.Scotty.Cookie (CookiesText)
 
 renderCookiesTable :: CookiesText -> H.Html
 renderCookiesTable cs =


### PR DESCRIPTION
As mentioned in #350 issue. I have exposed the cookie module from `Web.Scotty` & `Web.Scotty.Trans`. Though I only exported simple functions of the cookie module which are:

1. setSimpleCookie
2. getCookie
3. getCookies
4. deleteCookie
5. makeSimpleCookie

If the user wants to use `SetCookie` functions then the user should import `Web.Scotty.Cookie`. 
Let me know if I should expose all the functions or not.
Thanks.

@ocramz 