### PR TITLE
(#396) Fixed unwated behaviour of files and filesOpts while not uploading file.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,7 @@
 ### Breaking changes
 * Remove dependency on data-default class (#386). We have been exporting constants for default config values since 0.20, and this dependency was simply unnecessary.
 * Remove re-export of `Network.Wai.Parse.ParseRequestBodyOptions` from `Web.Scotty` and `Web.Scotty.Trans`. This is a type from `wai-extra` so exporting it is unnecessary.
-
+* (#396) Fixed unwated behaviour of `files` and `filesOpts` while not uploading any file.
 
 
 ## 0.22 [2024.03.09]

--- a/test/Web/ScottySpec.hs
+++ b/test/Web/ScottySpec.hs
@@ -380,7 +380,9 @@ spec = do
               (FMFile "file1.txt", "text/plain;charset=UTF-8", "file", "xxx"),
               (FMFile "file1.txt", "text/plain;charset=UTF-8", "file", "xxx")
               ] `shouldRespondWith` 413
-
+        context "Not uploading file should return empty list (#396)" $ do
+          it "Length of list should be 0" $ do
+            postMultipartForm "/files" "ABC123" [(FMFile "", "", "", "")] `shouldRespondWith` "0"
 
     describe "filesOpts" $ do
       let
@@ -401,6 +403,10 @@ spec = do
                     Scotty.post "/files" processForm) $ do
           it "loads uploaded files in memory" $ do
             postMpForm `shouldRespondWith` 200 { matchBody = "2"}
+      context "Not uploading file should return empty list (#396)" $ do
+        withApp (Scotty.post "/files" processForm) $ do
+          it "Length of list should be 0" $ do
+            postMultipartForm "/files" "ABC123" [(FMFile "", "", "", "")] `shouldRespondWith` "0"
 
 
     describe "text" $ do


### PR DESCRIPTION
Please visit issue #396 for more details.

## Issue
When using `files` or `filesOpts` function, upon not uploading any file, these function would still return a list of tuples containing filename as `"\"\""` and fileContent as `"\"\""`.

## Solution
- I added a filter function right after the `parseRequestBodyExBS` which converts the body into the list of FileInfo type, that will remove any file whose filename is `"\"\""`.
- I added the entry in `changelog.md` under `breaking changes` as well.

Thanks.
