### PR TITLE
Update Types.hs

### DIFF
--- a/Web/Scotty/Internal/Types.hs
+++ b/Web/Scotty/Internal/Types.hs
@@ -47,7 +47,7 @@ import UnliftIO.Exception (Handler(..), catch, catches)
 
 
 --------------------- Options -----------------------
-data Options = Options { verbose :: Int -- ^ 0 = silent, 1(def) = startup banner
+data Options = Options { verbose :: Int -- ^ Verbosity level: 0 = silent, 1 (default) = startup text, print unhandled exceptions to stderr
                        , settings :: W.Settings -- ^ Warp 'Settings'
                                               -- Note: to work around an issue in warp,
                                               -- the default FD cache duration is set to 0


### PR DESCRIPTION
The teeniest, tiniest of changes:
Improved docs for `verbose` parameter of the `Options` type. This documents the changes from #374 here as well.