### PR TITLE
pin http-api-data UB, fix warnings

### DIFF
--- a/Web/Scotty/Action.hs
+++ b/Web/Scotty/Action.hs
@@ -80,6 +80,7 @@ import qualified Data.ByteString.Lazy.Char8 as BL
 import qualified Data.CaseInsensitive       as CI
 import           Data.Traversable (for)
 import qualified Data.Map.Strict            as Map
+import qualified Data.HashMap.Strict        as HM
 import           Data.Int
 import           Data.List (foldl')
 import           Data.Maybe                 (maybeToList)
@@ -455,7 +456,7 @@ formData = do
     -- It's equivalent to using HashMap.insertWith (++) which does have
     -- quadratic complexity due to appending at the end of list.
     paramListToForm :: [Param] -> Form
-    paramListToForm = Form . fmap reverse . foldl' (\f (k, v) -> Map.alter (prependValue v) k f) Map.empty
+    paramListToForm = Form . fmap reverse . foldl' (\f (k, v) -> HM.alter (prependValue v) k f) HM.empty
 
     prependValue :: a -> Maybe [a] -> Maybe [a]
     prependValue v = Just . maybe [v] (v :)

--- a/examples/gzip.hs
+++ b/examples/gzip.hs
@@ -2,14 +2,14 @@
 module Main (main) where
 
 import Network.Wai.Middleware.RequestLogger
-import Network.Wai.Middleware.Gzip
+import Network.Wai.Middleware.Gzip (defaultGzipSettings, GzipSettings(..), GzipFiles(..), gzip)
 
 import Web.Scotty
 
 main :: IO ()
 main = scotty 3000 $ do
     -- Note that files are not gzip'd by the default settings.
-    middleware $ gzip $ def { gzipFiles = GzipCompress }
+    middleware $ gzip $ defaultGzipSettings { gzipFiles = GzipCompress }
     middleware logStdoutDev
 
     -- gzip a normal response

--- a/scotty.cabal
+++ b/scotty.cabal
@@ -79,7 +79,7 @@ Library
                        containers            >= 0.5      && < 0.8,
                        cookie                >= 0.4,
                        exceptions            >= 0.7      && < 0.11,
-                       http-api-data         >= 0.5.1,
+                       http-api-data         < 0.7,
                        http-types            >= 0.9.1    && < 0.13,
                        monad-control         >= 1.0.0.3  && < 1.1,
                        mtl                   >= 2.1.2    && < 2.4,


### PR DESCRIPTION
* http-api-data 0.7 has a breaking change ( HashMap -> Map , see https://github.com/fizruk/http-api-data/pull/156 )that somehow didn't raise alarms in our CI yet
* I suppressed some warnings in the gzip example